### PR TITLE
ENG-6593: remove -Wl as no linker options passed ubuntu 14.04 throws err...

### DIFF
--- a/makefile
+++ b/makefile
@@ -67,7 +67,7 @@ $(LIB_NAME).a: $(OBJS)
 
 $(LIB_NAME).so: $(OBJS)
 	@echo 'Building libvoltdbcpp.so shared library'
-	$(CC) -shared -Wl -o $@ $? $(THIRD_PARTY_LIBS) $(SYSTEM_LIBS)
+	$(CC) -shared -o $@ $? $(THIRD_PARTY_LIBS) $(SYSTEM_LIBS)
 	@echo
 
 $(KIT_NAME).tar.gz: $(LIB_NAME).a $(LIB_NAME).so


### PR DESCRIPTION
...or.
