### PR TITLE
Add exception for unsupported types

### DIFF
--- a/include/Exception.hpp
+++ b/include/Exception.hpp
@@ -159,6 +159,31 @@ public:
 };
 
 /*
+ * Thrown when a user attempts to use a type that is not supported.
+ * Users may see this exception.
+ */
+class UnsupportedTypeException : public voltdb::Exception {
+public:
+
+    explicit UnsupportedTypeException(const std::string& typeName) :
+        Exception() {
+        char msg[256];
+        snprintf(msg, sizeof msg, "Attempted to use a SQL type that is unsupported in the C++ client: %s", typeName.c_str());
+        m_what = msg;
+    }
+
+    virtual ~UnsupportedTypeException() throw() {}
+
+    virtual const char* what() const throw() {
+        return m_what.c_str();
+    }
+
+private:
+
+    std::string m_what;
+};
+
+/*
  * Thrown by Distributer when detects server run in LEGACY mode
  */
 class ElasticModeMismatchException : public voltdb::Exception {

--- a/include/ParameterSet.hpp
+++ b/include/ParameterSet.hpp
@@ -69,7 +69,7 @@ public:
     template <WireType T>
     ParameterSet& addTypedBytes(const int32_t size, const uint8_t *value)
     throw (voltdb::ParamMismatchException) {
-        assert(WIRE_TYPE_VARBINARY==T || WIRE_TYPE_STRING == T);
+        assert(WIRE_TYPE_VARBINARY == T || WIRE_TYPE_STRING == T);
         validateType(T, false);
         if (value) {
             m_buffer.ensureRemaining(1 + 4 + size);
@@ -112,7 +112,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addBytes(const int32_t size, const uint8_t *value) 
+    ParameterSet& addBytes(const int32_t size, const uint8_t *value)
     throw (voltdb::ParamMismatchException) {
         return addTypedBytes<WIRE_TYPE_VARBINARY>(size, value);
     }
@@ -450,7 +450,7 @@ public:
 
 private:
 
-    ParameterSet(std::vector<Parameter> parameters): 
+    ParameterSet(std::vector<Parameter> parameters):
         m_parameters(parameters)
        ,m_buffer(8192)
        ,m_currentParam(0)

--- a/include/Row.hpp
+++ b/include/Row.hpp
@@ -227,11 +227,33 @@ public:
     }
 
     /*
+     * Retrieve the value at the specified column index as a geographical point.
+     * This data type is not currently supported by the C++ client so this always
+     * throws an exception.
+     * @throws UnsupportedTypeException always
+     * @return never returns
+     */
+    void getGeographyPoint(int32_t column) {
+        throw UnsupportedTypeException(wireTypeToString(WIRE_TYPE_GEOGRAPHY_POINT));
+    }
+
+    /*
+     * Retrieve the value at the specified column index as a geographical object.
+     * This data type is not currently supported by the C++ client so this always
+     * throws an exception.
+     * @throws UnsupportedTypeException always
+     * @return never returns
+     */
+    void getGeography(int32_t column) {
+        throw UnsupportedTypeException(wireTypeToString(WIRE_TYPE_GEOGRAPHY));
+    }
+
+    /*
      * Returns true if the value at the specified column index is NULL and false otherwise
      * @throws InvalidColumnException The name of the column was invalid.
      * @return true if the value is NULL and false otherwise
      */
-    bool isNull(int32_t column) throw(voltdb::InvalidColumnException) {
+    bool isNull(int32_t column) throw(voltdb::InvalidColumnException, voltdb::UnsupportedTypeException) {
         if (column < 0 || column >= static_cast<ssize_t>(m_columns->size())) {
             throw InvalidColumnException(column);
         }
@@ -257,7 +279,7 @@ public:
             int out_len;
             getVarbinary(column, 0, NULL, &out_len); break;
         default:
-            assert(false);
+            throw UnsupportedTypeException(wireTypeToString(columnType));
         }
         return wasNull();
     }
@@ -269,7 +291,7 @@ public:
      * not match the type of the get method.
      * @return Whether the buffer provided was large enough.
      */
-    bool getVarbinary(const std::string& cname, int32_t bufsize, uint8_t *out_value, int32_t *out_len) 
+    bool getVarbinary(const std::string& cname, int32_t bufsize, uint8_t *out_value, int32_t *out_len)
     throw(voltdb::InvalidColumnException) {
         return getVarbinary(getColumnIndexByName(cname), bufsize, out_value, out_len);
     }
@@ -363,6 +385,28 @@ public:
     }
 
     /*
+     * Retrieve the value at the specified column name as a geographical point.
+     * This data type is not currently supported by the C++ client so this always
+     * throws an exception.
+     * @throws UnsupportedTypeException always
+     * @return never returns
+     */
+    void getGeographyPoint(const std::string& cname) throw(UnsupportedTypeException) {
+        return getGeographyPoint(getColumnIndexByName(cname));
+    }
+
+    /*
+     * Retrieve the value at the specified column name as a geographical object.
+     * This data type is not currently supported by the C++ client so this always
+     * throws an exception.
+     * @throws UnsupportedTypeException always
+     * @return never returns
+     */
+    void getGeography(const std::string& cname) throw(UnsupportedTypeException) {
+        return getGeography(getColumnIndexByName(cname));
+    }
+
+    /*
      * Returns true if the value in the column with the specified name is NULL and false otherwise
      * @throws InvalidColumnException The name of the column was invalid.
      * @return true if the value is NULL and false otherwise
@@ -420,7 +464,7 @@ public:
                 ostream << getTimestamp(ii); break;
             case WIRE_TYPE_DECIMAL:
                 ostream << getDecimal(ii).toString(); break;
-            case WIRE_TYPE_VARBINARY:  
+            case WIRE_TYPE_VARBINARY:
                 ostream << "VARBINARY VALUE"; break;
             default:
                 assert(false);
@@ -444,48 +488,48 @@ private:
         WireType columnType = m_columns->at(static_cast<size_t>(index)).m_type;
         switch (columnType) {
         case WIRE_TYPE_DECIMAL:
-            if (type != WIRE_TYPE_DECIMAL) 
+            if (type != WIRE_TYPE_DECIMAL)
                 throw InvalidColumnException(getColumnNameByIndex(index), type, wireTypeToString(type), wireTypeToString(WIRE_TYPE_DECIMAL));
             break;
         case WIRE_TYPE_TIMESTAMP:
-            if (type != WIRE_TYPE_TIMESTAMP) 
+            if (type != WIRE_TYPE_TIMESTAMP)
                 throw InvalidColumnException(getColumnNameByIndex(index), type, wireTypeToString(type), wireTypeToString(WIRE_TYPE_TIMESTAMP));
             break;
         case WIRE_TYPE_BIGINT:
-            if (type != WIRE_TYPE_BIGINT) 
+            if (type != WIRE_TYPE_BIGINT)
                 throw InvalidColumnException(getColumnNameByIndex(index), type, wireTypeToString(type), wireTypeToString(WIRE_TYPE_BIGINT));
             break;
         case WIRE_TYPE_INTEGER:
-            if (type != WIRE_TYPE_BIGINT && type != WIRE_TYPE_INTEGER) 
+            if (type != WIRE_TYPE_BIGINT && type != WIRE_TYPE_INTEGER)
                 throw InvalidColumnException(getColumnNameByIndex(index), type, wireTypeToString(type), wireTypeToString(WIRE_TYPE_INTEGER));
             break;
         case WIRE_TYPE_SMALLINT:
             if (type != WIRE_TYPE_BIGINT &&
                     type != WIRE_TYPE_INTEGER &&
-                    type != WIRE_TYPE_SMALLINT) 
+                    type != WIRE_TYPE_SMALLINT)
                 throw InvalidColumnException(getColumnNameByIndex(index), type, wireTypeToString(type), wireTypeToString(WIRE_TYPE_SMALLINT));
             break;
         case WIRE_TYPE_TINYINT:
             if (type != WIRE_TYPE_BIGINT &&
                     type != WIRE_TYPE_INTEGER &&
                     type != WIRE_TYPE_SMALLINT &&
-                    type != WIRE_TYPE_TINYINT) 
+                    type != WIRE_TYPE_TINYINT)
                 throw InvalidColumnException(getColumnNameByIndex(index), type, wireTypeToString(type), wireTypeToString(WIRE_TYPE_TINYINT));
             break;
         case WIRE_TYPE_FLOAT:
-            if (type != WIRE_TYPE_FLOAT) 
+            if (type != WIRE_TYPE_FLOAT)
                 throw InvalidColumnException(getColumnNameByIndex(index), type, wireTypeToString(type), wireTypeToString(WIRE_TYPE_FLOAT));
             break;
         case WIRE_TYPE_STRING:
-            if (type != WIRE_TYPE_STRING) 
+            if (type != WIRE_TYPE_STRING)
                 throw InvalidColumnException(getColumnNameByIndex(index), type, wireTypeToString(type), wireTypeToString(WIRE_TYPE_STRING));
             break;
         case WIRE_TYPE_VARBINARY:
-            if (type != WIRE_TYPE_VARBINARY) 
+            if (type != WIRE_TYPE_VARBINARY)
                 throw InvalidColumnException(getColumnNameByIndex(index), type, wireTypeToString(type), wireTypeToString(WIRE_TYPE_VARBINARY));
             break;
         default:
-            assert(false);
+            throw UnsupportedTypeException(wireTypeToString(columnType));
             break;
         }
         return columnType;
@@ -539,7 +583,7 @@ private:
                     length = 1;
                     break;
                 default:
-                    assert(false);
+                    throw UnsupportedTypeException(wireTypeToString(type));
                 }
                 m_offsets[static_cast<size_t>(i)] = m_offsets[static_cast<size_t>(i - 1)] + length;
             }

--- a/include/WireType.h
+++ b/include/WireType.h
@@ -27,6 +27,11 @@
 #include <string>
 
 namespace voltdb {
+/*
+ * Note: these constants must be the same as those in:
+ *   frontend/org/voltdb/VoltType.java
+ *   ee/common/types.h
+ */
 enum WireType {
     WIRE_TYPE_INVALID = -98,
     WIRE_TYPE_ARRAY = -99,

--- a/include/WireType.h
+++ b/include/WireType.h
@@ -39,7 +39,9 @@ enum WireType {
     WIRE_TYPE_STRING = 9,
     WIRE_TYPE_TIMESTAMP = 11,
     WIRE_TYPE_DECIMAL = 22,
-    WIRE_TYPE_VARBINARY = 25
+    WIRE_TYPE_VARBINARY = 25,
+    WIRE_TYPE_GEOGRAPHY_POINT = 26, // currenty unsupported
+    WIRE_TYPE_GEOGRAPHY = 27,       // currenty unsupported
 };
 
 std::string wireTypeToString(WireType type);

--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ ifeq ($(PLATFORM),Darwin)
 endif
 ifeq ($(PLATFORM),Linux)
 	THIRD_PARTY_DIR := third_party_libs/linux
-	SYSTEM_LIBS := -lc -lpthread -lrt -lboost_system -lboost_thread-mt
+	SYSTEM_LIBS := -lc -lpthread -lrt -lboost_system -lboost_thread
 	CFLAGS += -fPIC
 endif
 

--- a/src/WireType.cpp
+++ b/src/WireType.cpp
@@ -48,8 +48,12 @@ std::string wireTypeToString(WireType type) {
         return std::string("DECIMAL");
     case WIRE_TYPE_VARBINARY:
         return std::string("VARBINARY");
+    case WIRE_TYPE_GEOGRAPHY_POINT:
+        return std::string("GEOGRAPHY_POINT");
+    case WIRE_TYPE_GEOGRAPHY:
+        return std::string("GEOGRAPHY");
     default:
-        assert(false);
+        return std::string("<<Unknown Type>>");
     }
 }
 }


### PR DESCRIPTION
I tested selecting from a table with geo types by hand.  It's possible to retrieve such a table, but extracting column values produces the new exception that I added.