### PR TITLE
ENG-10480: turning on client affinity produces bad invocation response

### DIFF
--- a/include/Client.h
+++ b/include/Client.h
@@ -125,6 +125,12 @@ public:
     bool drain() throw (voltdb::NoConnectionsException, voltdb::LibEventException, voltdb::Exception);
 
     /*
+     * Returns true if this client is draining; i.e., still processing
+     * requests after receiving a call to drain().
+     */
+    bool isDraining() const;
+
+    /*
      * If one of the run family of methods is running on another thread, this
      * method will instruct it to exit as soon as it finishes it's current
      * immediate task. If the thread in the run method is blocked/idle, then
@@ -164,8 +170,10 @@ public:
     void setLoggerCallback(ClientLogger *pLogger);
 
     int32_t outstandingRequests() const;
+
     ~Client();
 private:
+
     /*
      * Disable various constructors and assignment
      */

--- a/include/ClientImpl.h
+++ b/include/ClientImpl.h
@@ -91,6 +91,7 @@ public:
     * @return true if all requests were drained and false otherwise
     */
     bool drain() throw (voltdb::Exception, voltdb::NoConnectionsException, voltdb::LibEventException);
+    bool isDraining() const { return m_isDraining; }
     ~ClientImpl();
 
     void regularReadCallback(struct bufferevent *bev);

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -93,6 +93,11 @@ throw (voltdb::Exception, voltdb::NoConnectionsException, voltdb::LibEventExcept
     return m_impl->drain();
 }
 
+bool
+Client::isDraining() const {
+    return m_impl->isDraining();
+}
+
 void Client::interrupt() {
     return m_impl->interrupt();
 }

--- a/src/ClientImpl.cpp
+++ b/src/ClientImpl.cpp
@@ -584,6 +584,7 @@ private:
 };
 
 InvocationResponse ClientImpl::invoke(Procedure &proc) throw (voltdb::Exception, voltdb::NoConnectionsException, voltdb::UninitializedParamsException, voltdb::LibEventException) {
+
     // Before making a synchronous request, process any existing requests.
     while (! drain()) {}
 
@@ -861,6 +862,7 @@ void ClientImpl::regularReadCallback(struct bufferevent *bev) {
 
             //If the client is draining and it just drained the last request, break the loop
             if (m_isDraining && m_outstandingRequests == 0) {
+                m_isDraining = false;
                 breakEventLoop = true;
             } else if (m_loopBreakRequested && (m_outstandingRequests <= m_maxOutstandingRequests)) {
                 // ignore break requested until we have too many outstanding requests
@@ -927,6 +929,7 @@ void ClientImpl::regularEventCallback(struct bufferevent *bev, short events) {
         }
 
         if (m_isDraining && m_outstandingRequests == 0) {
+            m_isDraining = false;
             breakEventLoop = true;
         }
 

--- a/src/ClientImpl.cpp
+++ b/src/ClientImpl.cpp
@@ -584,9 +584,13 @@ private:
 };
 
 InvocationResponse ClientImpl::invoke(Procedure &proc) throw (voltdb::Exception, voltdb::NoConnectionsException, voltdb::UninitializedParamsException, voltdb::LibEventException) {
+    // Before making a synchronous request, process any existing requests.
+    while (! drain()) {}
+
     if (m_bevs.empty()) {
         throw voltdb::NoConnectionsException();
     }
+
     int32_t messageSize = proc.getSerializedSize();
     ScopedByteBuffer sbb(messageSize);
     int64_t clientData = m_nextRequestId++;
@@ -600,9 +604,11 @@ InvocationResponse ClientImpl::invoke(Procedure &proc) throw (voltdb::Exception,
     }
     m_outstandingRequests++;
     (*m_callbacks[bev])[clientData] = callback;
+
     if (event_base_dispatch(m_base) == -1) {
         throw voltdb::LibEventException();
     }
+
     m_loopBreakRequested = false;
     return response;
 }

--- a/test_src/ClientTest.cpp
+++ b/test_src/ClientTest.cpp
@@ -508,6 +508,7 @@ public:
         }
         (m_client)->drain();
         CPPUNIT_ASSERT(cb->m_count == 0);
+        CPPUNIT_ASSERT(! m_client->isDraining());
     }
 
     class CountingSuccessAndConnectionLost : public voltdb::ProcedureCallback {
@@ -563,8 +564,8 @@ public:
 
         // Now do a synchronized invocation
         InvocationResponse response = m_client->invoke(proc);
-        CPPUNIT_ASSERT(response.responseReceived() == true);
         CPPUNIT_ASSERT(response.statusCode() == STATUS_CODE_SUCCESS);
+        CPPUNIT_ASSERT(! m_client->isDraining());
 
         // Queued invocations will have been processed before the synchronous invocation.
         CPPUNIT_ASSERT(cb->m_success == 2);


### PR DESCRIPTION
The issue here doesn't have anything to do with client affinity specifically, rather it has to do with how asynchronous SP invocations interact with synchronous ones. 

The setClientAffinity method makes a couple async SP invocations under the hood, and then the Voter example invokes the Initialize SP synchronously. The C++ driver just runs the event loop once for synchronous invocations, so if there are previously queued requests, then it may return before the synchronous invocation has received its response. 

My fix is to make sure we complete any queued invocations before making a synchronous invocation.

I also fixed an issue I found where we weren't unsetting the `isDraining` bit after draining is complete.