### PR TITLE
Eng 11353 pc

### DIFF
--- a/include/ClientImpl.h
+++ b/include/ClientImpl.h
@@ -134,7 +134,7 @@ private:
     ClientImpl(ClientConfig config) throw (voltdb::Exception, voltdb::LibEventException);
 
     void initiateAuthentication(struct bufferevent *bev) throw (voltdb::LibEventException);
-    void finalizeAuthentication(PendingConnection* pc, struct bufferevent *bev) throw (voltdb::Exception, voltdb::ConnectException);
+    void finalizeAuthentication(PendingConnection* pc) throw (voltdb::Exception, voltdb::ConnectException);
 
     /*
      * Updates procedures and topology information for transaction routing algorithm

--- a/src/ClientImpl.cpp
+++ b/src/ClientImpl.cpp
@@ -127,6 +127,12 @@ static void authenticationReadCallback(struct bufferevent *bev, void *ctx) {
     struct evbuffer *evbuf = bufferevent_get_input(bev);
 
     assert(pc->m_bufferEvent == bev);
+    if (pc->m_bufferEvent != bev) {
+        std::ostringstream os;
+        os << "authenticationReadCallback, PC buffer event: " << pc->m_bufferEvent
+                << ", bev: " << bev;
+        std::cerr << os.str() << std::endl;
+    }
     if (pc->m_authenticationResponseLength < 0) {
         char messageLengthBytes[4];
         int read = evbuffer_remove(evbuf, messageLengthBytes, 4);


### PR DESCRIPTION
Update to cash buffer event in pending connection to handle scenario for keepalive where socket has not triggered any event and the reconnectEvent has been triggered. This can lead to a potential scenario where same pending connection can get associated with different buffer events which may result in SegV while running events for second buffer event.