### PR TITLE
Logic update for backpressure notification n setaffinity invocations under backpressure

### DIFF
--- a/include/ClientImpl.h
+++ b/include/ClientImpl.h
@@ -184,6 +184,7 @@ private:
     BEVToCallbackMap m_callbacks;
     boost::shared_ptr<voltdb::StatusListener> m_listener;
     bool m_invocationBlockedOnBackpressure;
+    bool m_backPressuredForOutstandingRequests;
     boost::atomic<bool> m_loopBreakRequested;
     bool m_isDraining;
     bool m_instanceIdIsSet;

--- a/include/ProcedureCallback.hpp
+++ b/include/ProcedureCallback.hpp
@@ -47,6 +47,10 @@ public:
      */
     virtual bool callback(InvocationResponse response) throw (voltdb::Exception) = 0;
     virtual void abandon(AbandonReason reason) {}
+    // Mechanism for procedure to over-ride abandon property set in client in event of backpressure.
+    // @return true: honor the abandoning of requests in case of back pressure
+    //         false: don't abandon the requests in back pressure scenario.
+    virtual bool honorDoAbandon() const {return true;}
     virtual ~ProcedureCallback() {}
 };
 }

--- a/include/StatusListener.h
+++ b/include/StatusListener.h
@@ -62,7 +62,7 @@ public:
      * @return true if the event loop should terminate and false otherwise
      */
     virtual bool connectionActive(std::string hostname, int32_t connectionsActive) = 0;
-   
+
     /*
      * Notify the client application that backpressure occured
      * @param hasBackpressure True if backpressure is beginning and false if it is ending

--- a/src/ClientImpl.cpp
+++ b/src/ClientImpl.cpp
@@ -685,8 +685,8 @@ public:
 
     void abandon(AbandonReason reason) {}
 
-    bool honorDoAbandon() const {
-        return m_callback->honorDoAbandon();
+    bool allowAbandon() const {
+        return m_callback->allowAbandon();
     }
 
 };
@@ -742,7 +742,7 @@ void ClientImpl::invoke(Procedure &proc, boost::shared_ptr<ProcedureCallback> ca
             }
         }
     	// We are overloaded, we need to reject traffic and notify the caller
-        if (m_enableAbandon && callback->honorDoAbandon()) {
+        if (m_enableAbandon && callback->allowAbandon()) {
             callback->abandon(ProcedureCallback::TOO_BUSY);
             return;
         }
@@ -1139,7 +1139,7 @@ public:
         return true;
     }
 
-    bool honorDoAbandon() const {return false;}
+    bool allowAbandon() const {return false;}
 };
 
 /*
@@ -1160,7 +1160,7 @@ public:
         return true;
     }
 
-    bool honorDoAbandon() const {return false;}
+    bool allowAbandon() const {return false;}
 
  private:
     Distributer *m_dist;

--- a/src/ClientImpl.cpp
+++ b/src/ClientImpl.cpp
@@ -288,7 +288,8 @@ const std::string ClientImpl::SERVICE("database");
 
 ClientImpl::ClientImpl(ClientConfig config) throw(voltdb::Exception, voltdb::LibEventException) :
         m_base(NULL), m_ev(NULL), m_cfg(NULL), m_nextRequestId(INT64_MIN), m_nextConnectionIndex(0),
-        m_listener(config.m_listener), m_invocationBlockedOnBackpressure(false), m_loopBreakRequested(false),
+        m_listener(config.m_listener), m_invocationBlockedOnBackpressure(false),
+        m_backPressuredForOutstandingRequests(false), m_loopBreakRequested(false),
         m_isDraining(false), m_instanceIdIsSet(false), m_outstandingRequests(0), m_leaderAddress(-1),
         m_clusterStartTime(-1), m_username(config.m_username), m_maxOutstandingRequests(config.m_maxOutstandingRequests),
         m_ignoreBackpressure(false), m_useClientAffinity(false),m_updateHashinator(false), m_pendingConnectionSize(0),
@@ -684,6 +685,10 @@ public:
 
     void abandon(AbandonReason reason) {}
 
+    bool honorDoAbandon() const {
+        return m_callback->honorDoAbandon();
+    }
+
 };
 
 void ClientImpl::invoke(Procedure &proc, ProcedureCallback *callback) throw (voltdb::Exception, voltdb::NoConnectionsException, voltdb::UninitializedParamsException, voltdb::LibEventException, voltdb::ElasticModeMismatchException) {
@@ -729,6 +734,7 @@ void ClientImpl::invoke(Procedure &proc, boost::shared_ptr<ProcedureCallback> ca
 
     if (m_outstandingRequests >= m_maxOutstandingRequests) {
     	if (m_listener.get() != NULL) {
+            m_backPressuredForOutstandingRequests = true;
             try {
                 m_listener->backpressure(true);
             } catch (const std::exception& e) {
@@ -736,9 +742,13 @@ void ClientImpl::invoke(Procedure &proc, boost::shared_ptr<ProcedureCallback> ca
             }
         }
     	// We are overloaded, we need to reject traffic and notify the caller
-        if (m_enableAbandon) {
+        if (m_enableAbandon && callback->honorDoAbandon()) {
             callback->abandon(ProcedureCallback::TOO_BUSY);
             return;
+        }
+        else if (m_enableAbandon) {
+            // report to client the request was not abandoned
+            callback->abandon(ProcedureCallback::NOT_ABANDONED);
         }
     }
 
@@ -795,6 +805,7 @@ void ClientImpl::invoke(Procedure &proc, boost::shared_ptr<ProcedureCallback> ca
             break;
         } else {
             bool callEventLoop = true;
+
             if (m_listener.get() != NULL) {
                 try {
                     m_ignoreBackpressure = true;
@@ -806,8 +817,14 @@ void ClientImpl::invoke(Procedure &proc, boost::shared_ptr<ProcedureCallback> ca
             }
             if (callEventLoop) {
                 m_invocationBlockedOnBackpressure = true;
-                if (event_base_dispatch(m_base) == -1) {
+                int loopRunStatus = event_base_dispatch(m_base);
+                if (loopRunStatus == -1) {
                     throw voltdb::LibEventException();
+                }
+                else if (loopRunStatus == 1) {
+                    if (m_pLogger) {
+                        logMessage(ClientLogger::DEBUG, "No events queued for processing");
+                    }
                 }
                 if (m_loopBreakRequested) {
                     m_loopBreakRequested = false;
@@ -942,6 +959,17 @@ void ClientImpl::regularReadCallback(struct bufferevent *bev) {
         }
     }
 
+    if ((m_outstandingRequests < m_maxOutstandingRequests) && m_backPressuredForOutstandingRequests) {
+        if (m_listener.get() != NULL) {
+            m_backPressuredForOutstandingRequests = false;
+            try {
+                m_listener->backpressure(false);
+            }
+            catch (std::exception &excp) {
+                std::cerr << "Caught exception when notifying for backpressure gone: " << excp.what() << std::endl;
+            }
+        }
+    }
     if (breakEventLoop) {
         event_base_loopbreak( m_base );
     }
@@ -998,6 +1026,10 @@ void ClientImpl::regularEventCallback(struct bufferevent *bev, short events) {
 
         //remove the entry for the backpressured connection set
         m_backpressuredBevs.erase(bev);
+        if (m_outstandingRequests < m_maxOutstandingRequests) {
+            m_backPressuredForOutstandingRequests = false;
+        }
+
         createPendingConnection(m_contexts[bev]->m_name, m_contexts[bev]->m_port, get_sec_time());
 
         //Remove the connection context
@@ -1032,10 +1064,12 @@ void ClientImpl::regularWriteCallback(struct bufferevent *bev) {
             m_backpressuredBevs.find(bev);
     if (iter != m_backpressuredBevs.end()) {
         m_backpressuredBevs.erase(iter);
-        try {
-            m_listener->backpressure(false);
-        } catch (const std::exception& excp) {
-            std::cerr << "Caught exception while reporting backpressure off. " << excp.what() << std::endl;
+        if (m_listener.get() != NULL) {
+            try {
+                m_listener->backpressure(false);
+            } catch (const std::exception& excp) {
+                std::cerr << "Caught exception while reporting backpressure off. " << excp.what() << std::endl;
+            }
         }
     }
     if (m_invocationBlockedOnBackpressure) {
@@ -1104,6 +1138,8 @@ public:
         }
         return true;
     }
+
+    bool honorDoAbandon() const {return false;}
 };
 
 /*
@@ -1112,7 +1148,8 @@ public:
 class ProcUpdateCallback : public voltdb::ProcedureCallback
 {
 public:
-    ProcUpdateCallback(Distributer *dist):m_dist(dist){}
+    ProcUpdateCallback(Distributer *dist):m_dist(dist) {}
+
     bool callback(InvocationResponse response) throw (voltdb::Exception)
     {
         if (response.failure()) {
@@ -1122,6 +1159,8 @@ public:
         m_dist->updateProcedurePartitioning(response.results());
         return true;
     }
+
+    bool honorDoAbandon() const {return false;}
 
  private:
     Distributer *m_dist;


### PR DESCRIPTION
- Update to client logic to report when systems steps out from backpressure either due to outstanding requests or exceeding high watermark on buffer events data. 
- Update to procedure invocation logic to support over-ride mechanism to signal whether to honor abandon of proc request or not. This is specifically put in for scenario where requests like topo update for set client affinity does not get dropped due to abandon request under back-pressure set.