### PR TITLE
Simplify createConnection usage and pendingConnectionList handling

### DIFF
--- a/include/Client.h
+++ b/include/Client.h
@@ -48,14 +48,16 @@ class ProcedureCallback;
 class Client {
     friend class MockVoltDB;
 public:
+
     /*
-     * Create a connection to the VoltDB process running at the specified host authenticating
-     * using the username and password provided when this client was constructed
+     * Creates a pending connection that is handled in the reconnect callback 
      * @param hostname Hostname or IP address to connect to
+     * @param port Port to connect to
+     * @param defer if true defer connection establishment
      * @throws voltdb::ConnectException An error occurs connecting or authenticating
      * @throws voltdb::LibEventException libevent returns an error code
      */
-    void createConnection(const std::string &hostname, const unsigned short port = 21212, const bool keepConnecting = false) throw (voltdb::ConnectException, voltdb::LibEventException, voltdb::Exception);
+    void createConnection(const std::string &hostname, const unsigned short port = 21212, const bool keepConnecting = false, const bool defer = false) throw (voltdb::Exception, voltdb::ConnectException, voltdb::LibEventException);
 
     /*
      * Close client connection.

--- a/include/ClientImpl.h
+++ b/include/ClientImpl.h
@@ -55,10 +55,10 @@ class ClientImpl {
 
 public:
     /*
-     * Create a connection to the VoltDB process running at the specified host authenticating
-     * using the username and password provided when this client was constructed
+     * Creates a connection that is handled in the reconnect callback
      * @param hostname Hostname or IP address to connect to
      * @param port Port to connect to
+     * @param  defer if true defer connection establishment 
      * @throws voltdb::ConnectException An error occurs connecting or authenticating
      * @throws voltdb::LibEventException libevent returns an error code
      * @throws voltdb::PipeCreationException Fails to create pipe for communication
@@ -66,7 +66,8 @@ public:
      * @throws voltdb::TimerThreadException error happens when creating query timer monitor thread
      * @throws voltdb::SSLException ssl operations returns an error
      */
-    void createConnection(const std::string &hostname, const unsigned short port, const bool keepConnecting) throw (Exception, ConnectException, LibEventException, PipeCreationException, TimerThreadException, SSLException);
+    void createConnection(const std::string &hostname, const unsigned short port=21212, const bool keepConnecting=false, const bool defer=false)
+        throw (voltdb::Exception, voltdb::ConnectException, voltdb::LibEventException, voltdb::PipeCreationException, voltdb::TimerThreadException, voltdb::SSLException);
 
     /*
      * Synchronously invoke a stored procedure and return a the response.
@@ -93,7 +94,7 @@ public:
     void regularEventCallback(struct bufferevent *bev, short events);
     void regularWriteCallback(struct bufferevent *bev);
     void eventBaseLoopBreak();
-    void reconnectEventCallback();
+    void reconnectEventCallback(const boost::shared_ptr<PendingConnection>& pc);
 
     void runTimeoutMonitor() throw (LibEventException);
     void purgeExpiredRequests();
@@ -135,8 +136,10 @@ public:
 private:
     ClientImpl(ClientConfig config) throw (Exception, LibEventException, MDHashException, SSLException);
 
-    void initiateAuthentication(struct bufferevent *bev, const std::string& hostname, unsigned short port) throw (LibEventException);
-    void finalizeAuthentication(PendingConnection* pc) throw (Exception, ConnectException);
+    void createConnectionSync(const std::string &hostname, const unsigned short port, const bool keepConnecting)
+	  throw (voltdb::Exception, voltdb::ConnectException, voltdb::LibEventException, voltdb::PipeCreationException, voltdb::TimerThreadException, voltdb::SSLException);
+    void initiateAuthentication(struct bufferevent *bev, const std::string& hostname, unsigned short port) throw (voltdb::LibEventException);
+    void finalizeAuthentication(PendingConnection* pc) throw (voltdb::Exception, voltdb::ConnectException);
 
     /*
      * Updates procedures and topology information for transaction routing algorithm
@@ -156,7 +159,7 @@ private:
     /*
      * Initiate connection based on pending connection instance
      */
-    void initiateConnection(boost::shared_ptr<PendingConnection> &pc) throw (ConnectException, LibEventException, SSLException);
+    void initiateConnection(const boost::shared_ptr<PendingConnection> &pc) throw (voltdb::ConnectException, voltdb::LibEventException, voltdb::SSLException);
 
     /*
      * Creates a pending connection that is handled in the reconnect callback
@@ -192,7 +195,6 @@ private:
             }
         }
     }
-
     /*
      * Method for sinking messages.
      * If a logger callback is not set then skip all messages
@@ -266,9 +268,7 @@ private:
     //If to use abandon in case of backpressure.
     bool m_enableAbandon;
 
-    std::list<boost::shared_ptr<PendingConnection> > m_pendingConnectionList;
-    boost::atomic<size_t> m_pendingConnectionSize;
-    boost::mutex m_pendingConnectionLock;
+    std::vector<boost::shared_ptr<PendingConnection> > m_pendingConnectionList;
 
     int m_wakeupPipe[2];
     boost::mutex m_wakeupPipeLock;

--- a/include/ClientImpl.h
+++ b/include/ClientImpl.h
@@ -55,9 +55,10 @@ class ClientImpl {
 
 public:
     /*
-     * Creates a connection that is handled in the reconnect callback
-     * @param hostname Hostname or IP address to connect to
-     * @param port Port to connect to
+     * Create a connection to the VoltDB process running at the specified host authenticating
+     * using the username and password provided when this client was constructed     
+     * @param  hostname Hostname or IP address to connect to
+     * @param  port Port to connect to
      * @param  defer if true defer connection establishment 
      * @throws voltdb::ConnectException An error occurs connecting or authenticating
      * @throws voltdb::LibEventException libevent returns an error code

--- a/include/GeographyPoint.hpp
+++ b/include/GeographyPoint.hpp
@@ -160,7 +160,7 @@ public:
     int32_t deserializeFrom(ByteBuffer &message,
                             int32_t     offset,
                             bool       &wasNull);
-    static const double NULL_COORDINATE = 360.0;
+    static constexpr double NULL_COORDINATE = 360.0;
 private:
     double m_longitude;
     double m_latitude;

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -36,12 +36,13 @@ Client::Client(ClientImpl *impl) : m_impl(impl) {}
 Client::~Client() {
 }
 
-void Client::createConnection(const std::string &hostname,
-                              const unsigned short port,
-                              const bool keepConnecting) throw (voltdb::Exception,
-                                                                voltdb::ConnectException,
-                                                                voltdb::LibEventException) {
-    m_impl->createConnection(hostname, port, keepConnecting);
+void 
+Client::createConnection(
+        const std::string &hostname, 
+        const unsigned short port,
+	const bool keepConnecting,
+        const bool defer)  throw (voltdb::Exception, voltdb::ConnectException, voltdb::LibEventException) {
+    m_impl->createConnection(hostname, port, defer);
 }
 
 void Client::close() {

--- a/test_src/ClientTest.cpp
+++ b/test_src/ClientTest.cpp
@@ -360,8 +360,8 @@ public:
         (m_client)->invoke(proc, callback);
         m_voltdb->hangupOnRequestCount(1);
 
-        (m_client)->run();
-        (m_client)->runOnce();
+       (m_client)->run();
+       (m_client)->runOnce();
     }
 
     class BreakingSyncCallback : public ProcedureCallback {

--- a/test_src/ClientTest.cpp
+++ b/test_src/ClientTest.cpp
@@ -360,8 +360,8 @@ public:
         (m_client)->invoke(proc, callback);
         m_voltdb->hangupOnRequestCount(1);
 
-       (m_client)->run();
-       (m_client)->runOnce();
+        (m_client)->run();
+        (m_client)->runOnce();
     }
 
     class BreakingSyncCallback : public ProcedureCallback {


### PR DESCRIPTION
Main idea is to simplify pendingConnectionList handling by accessing it only with in libevent handlers, this allowed lock and atomic removal around it. 

As well I changed createConnection so it handles both usecases, synchronous and deferred connects.