### PR TITLE
Change callback to store extra invokation info

### DIFF
--- a/include/ClientImpl.h
+++ b/include/ClientImpl.h
@@ -151,7 +151,7 @@ private:
     /*
      * Get the buffered event based on transaction routing algorithm
      */
-    struct bufferevent *routeProcedure(Procedure &proc, ScopedByteBuffer &sbb);
+    struct bufferevent *routeProcedure(Procedure &proc, ScopedByteBuffer &sbb, boost::shared_ptr<ProcedureCallback> callback);
 
     /*
      * Initiate connection based on pending connection instance

--- a/makefile
+++ b/makefile
@@ -14,7 +14,7 @@ BOOST_LIBS=/usr/local/lib
 LIB_NAME=libvoltdbcpp
 KIT_NAME=voltdb-client-cpp-x86_64-7.1
 
-CFLAGS=-I$(BOOST_INCLUDES) -Iinclude -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -g3 ${OPTIMIZATION} -fPIC
+CFLAGS=-I$(BOOST_INCLUDES) -Iinclude -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -g3 ${OPTIMIZATION} -fPIC -fpermissive
 PLATFORM = $(shell uname)
 
 ifeq ($(PLATFORM),Darwin)


### PR DESCRIPTION
This change is driven mainly by situations when invokations time out and extra information like routing&proc info is needed to be logged for troubleshooting. As well have a meaningful log entry when a late response comes in.