### PR TITLE
ENG-13612:

### DIFF
--- a/include/Client.h
+++ b/include/Client.h
@@ -115,6 +115,15 @@ public:
     void run() throw (voltdb::NoConnectionsException, voltdb::LibEventException, voltdb::Exception);
 
     /*
+     * Enter the event loop and process pending events until the specified time in microseconds has expired.
+     * This writes requests to any ready connections and reads all responses and invokes the appropriate callbacks.
+     * Returns only immediately after the loop is broken by a callback.
+     * @throws NoConnectionsException No connections to the database so there is no work to be done
+     * @throws LibEventException An unknown error occured in libevent
+     */
+    void runForMaxTime(uint64_t microseconds) throw (voltdb::NoConnectionsException, voltdb::LibEventException, voltdb::Exception);
+
+    /*
      * Enter the event loop and process pending events until all responses have been received and then return.
      * It is possible for drain to exit without having received all responses if a callback requests that the event
      * loop break in which case false will be returned.

--- a/include/ClientImpl.h
+++ b/include/ClientImpl.h
@@ -76,6 +76,7 @@ public:
     void invoke(Procedure &proc, ProcedureCallback *callback) throw (Exception, NoConnectionsException, UninitializedParamsException, LibEventException, ElasticModeMismatchException);
     void runOnce() throw (Exception, NoConnectionsException, LibEventException);
     void run() throw (Exception, NoConnectionsException, LibEventException);
+    void runForMaxTime(uint64_t microseconds) throw (Exception, NoConnectionsException, LibEventException);
 
    /*
     * Enter the event loop and process pending events until all responses have been received and then return.
@@ -131,6 +132,12 @@ public:
 
     int64_t getExpiredRequestsCount() const { return m_timedoutRequests; }
     int64_t getResponseWithHandlesNotInCallback() const { return m_responseHandleNotFound; }
+
+    /*
+     * Method for sinking messages.
+     * If a logger callback is not set then skip all messages
+     */
+    void logMessage(ClientLogger::CLIENT_LOG_LEVEL severity, const std::string& msg);
 
 private:
     ClientImpl(ClientConfig config) throw (Exception, LibEventException, MDHashException, SSLException);
@@ -192,12 +199,6 @@ private:
             }
         }
     }
-
-    /*
-     * Method for sinking messages.
-     * If a logger callback is not set then skip all messages
-     */
-    void logMessage(ClientLogger::CLIENT_LOG_LEVEL severity, const std::string& msg);
 
     void setUpTimeoutCheckerMonitor() throw (LibEventException);
     void startMonitorThread() throw (TimerThreadException);

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -86,6 +86,12 @@ void Client::run() throw (voltdb::Exception,
     m_impl->run();
 }
 
+void Client::runForMaxTime(uint64_t uSec) throw (voltdb::Exception,
+                                                 voltdb::NoConnectionsException,
+                                                 voltdb::LibEventException) {
+    m_impl->runForMaxTime(uSec);
+}
+
 bool Client::drain() throw (voltdb::Exception,
                             voltdb::NoConnectionsException,
                             voltdb::LibEventException) {


### PR DESCRIPTION
A new Interface is provided by the C++ client to allow the event loop to be run for a bounded amount to time. The method is called runForMaxTime and it takes a single unsigned long int parameter, representing the time to return control to the applicaion in microseconds.

Note that if an application callback returns false while in the runForMaxTime method, control will be returned immediately back to the client.