### PR TITLE
fix build error under GCC 7.2

### DIFF
--- a/include/GeographyPoint.hpp
+++ b/include/GeographyPoint.hpp
@@ -160,7 +160,7 @@ public:
     int32_t deserializeFrom(ByteBuffer &message,
                             int32_t     offset,
                             bool       &wasNull);
-    static const double NULL_COORDINATE = 360.0;
+    static const double NULL_COORDINATE;
 private:
     double m_longitude;
     double m_latitude;

--- a/src/GeographyPoint.cpp
+++ b/src/GeographyPoint.cpp
@@ -30,6 +30,7 @@
 #include "ByteBuffer.hpp"
 
 namespace voltdb {
+const double GeographyPoint::NULL_COORDINATE = 360;
 GeographyPoint::GeographyPoint()
     : m_longitude(360.0),
       m_latitude(360.0) {


### PR DESCRIPTION
There is a lot of warning under GCC 7.2 and one build error. This is only to fix the build error.

max@max:~/study/voltdb-client-cpp$ g++ -v
Using built-in specs.
COLLECT_GCC=g++
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/7/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 7.2.0-8ubuntu3' --with-bugurl=file:///usr/share/doc/gcc-7/README.Bugs --enable-languages=c,ada,c++,go,brig,d,fortran,objc,obj-c++ --prefix=/usr --with-gcc-major-version-only --program-suffix=-7 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --enable-default-pie --with-system-zlib --with-target-system-zlib --enable-objc-gc=auto --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 7.2.0 (Ubuntu 7.2.0-8ubuntu3)
max@max:~/study/voltdb-client-cpp$ make
Building file: src/Client.cpp
Invoking: GCC C++ Compiler
g++ -I/usr/local/include -Iinclude -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -g3 -O3 -fPIC -c -o obj/Client.o src/Client.cpp -MMD -MP
In file included from include/Table.h:27:0,
from include/ParameterSet.hpp:28,
from include/Procedure.hpp:28,
from include/Client.h:28,
from src/Client.cpp:24:
include/ByteBuffer.hpp:129:45: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void get(char *storage, int32_t length) throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:132:60: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void get(int32_t index, char *storage, int32_t length) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:135:58: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ByteBuffer& put(const char *storage, int32_t length) throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:139:73: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ByteBuffer& put(int32_t index, const char *storage, int32_t length) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
^~~~~
In file included from include/Table.h:27:0,
from include/ParameterSet.hpp:28,
from include/Procedure.hpp:28,
from include/Client.h:28,
from src/Client.cpp:24:
include/ByteBuffer.hpp:144:40: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ByteBuffer& put(ByteBuffer *other) throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:155:22: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
int8_t getInt8() throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:158:35: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
int8_t getInt8(int32_t index) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:161:39: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ByteBuffer& putInt8(int8_t value) throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:165:54: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ByteBuffer& putInt8(int32_t index, int8_t value) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:170:24: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
int16_t getInt16() throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:175:37: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
int16_t getInt16(int32_t index) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:180:41: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ByteBuffer& putInt16(int16_t value) throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:184:56: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ByteBuffer& putInt16(int32_t index, int16_t value) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:189:24: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
int32_t getInt32() throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:194:37: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
int32_t getInt32(int32_t index) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:199:41: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ByteBuffer& putInt32(int32_t value) throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:203:56: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ByteBuffer& putInt32(int32_t index, int32_t value) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:208:24: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
int64_t getInt64() throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:213:37: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
int64_t getInt64(int32_t index) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:218:41: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ByteBuffer& putInt64(int64_t value) throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:222:56: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ByteBuffer& putInt64(int32_t index, int64_t value) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:227:24: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
double getDouble() throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:235:37: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
double getDouble(int32_t index) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:243:41: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ByteBuffer& putDouble(double value) throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:250:56: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ByteBuffer& putDouble(int32_t index, double value) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:258:42: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
std::string getString(bool &wasNull) throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:267:57: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
std::string getString(int32_t index, bool &wasNull) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:278:5: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:292:5: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
throw (OverflowUnderflowException, IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:306:5: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:313:5: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
throw (OverflowUnderflowException, IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:321:5: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
throw (OverflowUnderflowException) {
^~~~~
include/ByteBuffer.hpp:326:5: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
throw (OverflowUnderflowException, IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:333:44: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ByteBuffer& position(int32_t position) throw (IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:349:41: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ByteBuffer& limit(int32_t newLimit) throw (IndexOutOfBoundsException) {
^~~~~
include/ByteBuffer.hpp:371:53: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
virtual void ensureRemaining(int32_t remaining) throw(NonExpandableBufferException) {
^~~~~
include/ByteBuffer.hpp:375:58: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
virtual void ensureRemainingExact(int32_t remaining) throw(NonExpandableBufferException) {
^~~~~
include/ByteBuffer.hpp:379:51: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
virtual void ensureCapacity(int32_t capacity) throw(NonExpandableBufferException) {
^~~~~
include/ByteBuffer.hpp:383:56: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
virtual void ensureCapacityExact(int32_t capacity) throw(NonExpandableBufferException) {
^~~~~
include/ByteBuffer.hpp:450:43: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void ensureRemaining(int32_t amount) throw(NonExpandableBufferException) {
^~~~~
include/ByteBuffer.hpp:455:48: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void ensureRemainingExact(int32_t amount) throw(NonExpandableBufferException) {
^~~~~
include/ByteBuffer.hpp:460:44: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void ensureCapacity(int32_t capacity) throw(NonExpandableBufferException) {
^~~~~
include/ByteBuffer.hpp:475:49: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void ensureCapacityExact(int32_t capacity) throw(NonExpandableBufferException) {
^~~~~
In file included from include/ParameterSet.hpp:28:0,
from include/Procedure.hpp:28,
from include/Client.h:28,
from src/Client.cpp:24:
include/Table.h:49:47: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
Table(const std::vector<Column> &columns) throw (TableException);
^~~~~
include/Table.h:76:34: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void addRow(RowBuilder& row) throw (TableException, UninitializedColumnException, InCompatibleSchemaException);
^~~~~
include/Table.h:98:45: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
int32_t serializeTo(ByteBuffer& buffer) throw (TableException);
^~~~~
include/Table.h:122:69: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void validateRowScehma(const std::vector<Column>& schema) const throw (InCompatibleSchemaException);
^~~~~
In file included from include/ParameterSet.hpp:31:0,
from include/Procedure.hpp:28,
from include/Client.h:28,
from src/Client.cpp:24:
include/GeographyPoint.hpp:163:25: error: ‘constexpr’ needed for in-class initialization of static data member ‘const double voltdb::GeographyPoint::NULL_COORDINATE’ of non-integral type [-fpermissive]
static const double NULL_COORDINATE = 360.0;
^~~~~~~~~~~~~~~
In file included from include/Procedure.hpp:28:0,
from include/Client.h:28,
from src/Client.cpp:24:
include/ParameterSet.hpp:72:5: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:91:9: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:117:5: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:126:4: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:135:43: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ParameterSet& addDecimal(Decimal val) throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:149:64: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ParameterSet& addDecimal(const std::vector<Decimal>& vals) throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:167:45: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ParameterSet& addTimestamp(int64_t val) throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:181:66: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ParameterSet& addTimestamp(const std::vector<int64_t>& vals) throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:199:41: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ParameterSet& addInt64(int64_t val) throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:213:62: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ParameterSet& addInt64(const std::vector<int64_t>& vals) throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:231:41: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ParameterSet& addInt32(int32_t val) throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:245:62: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ParameterSet& addInt32(const std::vector<int32_t>& vals) throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:263:41: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ParameterSet& addInt16(int16_t val) throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:277:62: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ParameterSet& addInt16(const std::vector<int16_t>& vals) throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:295:39: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ParameterSet& addInt8(int8_t val) throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:309:60: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ParameterSet& addInt8(const std::vector<int8_t>& vals) throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:327:41: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ParameterSet& addDouble(double val) throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:341:62: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ParameterSet& addDouble(const std::vector<double>& vals) throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:362:29: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ParameterSet& addNull() throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:378:5: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:388:5: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:398:5: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
throw (voltdb::ParamMismatchException) {
^~~~~
include/ParameterSet.hpp:408:5: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
throw (voltdb::ParamMismatchException) {
^~~~~
In file included from src/Client.cpp:24:0:
include/Client.h:58:126: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
st std::string &hostname, const unsigned short port = 21212, const bool keepConnecting = false) throw (voltdb::ConnectException, voltdb::LibEventException, voltdb::Exception);
^~~~~
In file included from src/Client.cpp:24:0:
include/Client.h:72:64: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
voltdb::InvocationResponse invoke(voltdb::Procedure &proc) throw (voltdb::NoConnectionsException, voltdb::UninitializedParamsException, voltdb::LibEventException, voltdb::Exception);
^~~~~
include/Client.h:86:97: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void invoke(voltdb::Procedure &proc, boost::shared_ptr<voltdb::ProcedureCallback> callback) throw (voltdb::NoConnectionsException, voltdb::UninitializedParamsException, voltdb::LibEventException, voltdb::Exception);
^~~~~
include/Client.h:97:79: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void invoke(voltdb::Procedure &proc, voltdb::ProcedureCallback *callback) throw (voltdb::NoConnectionsException, voltdb::UninitializedParamsException, voltdb::LibEventException, voltdb::Exception);
^~~~~
include/Client.h:106:20: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void runOnce() throw (voltdb::NoConnectionsException, voltdb::LibEventException, voltdb::Exception);
^~~~~
include/Client.h:115:16: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void run() throw (voltdb::NoConnectionsException, voltdb::LibEventException, voltdb::Exception);
^~~~~
include/Client.h:125:18: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
bool drain() throw (voltdb::NoConnectionsException, voltdb::LibEventException, voltdb::Exception);
^~~~~
include/Client.h:159:80: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
static Client create(voltdb::ClientConfig config = voltdb::ClientConfig()) throw(voltdb::LibEventException, voltdb::Exception);
^~~~~
include/Client.h:188:14: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
Client() throw(voltdb::LibEventException);
^~~~~
In file included from include/ClientImpl.h:35:0,
from src/Client.cpp:25:
include/ProcedureCallback.hpp:48:56: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
virtual bool callback(InvocationResponse response) throw (voltdb::Exception) = 0;
^~~~~
In file included from include/ClientImpl.h:42:0,
from src/Client.cpp:25:
include/Distributer.h:80:63: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecate ]
ProcedureInfo* getProcedure(const std::string& procName) throw (UnknownProcedureException);
^~~~~
In file included from src/Client.cpp:25:0:
include/ClientImpl.h:69:110: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecate ]
teConnection(const std::string &hostname, const unsigned short port, const bool keepConnecting) throw (Exception, ConnectException, LibEventException, PipeCreationException, TimerThreadException, SSLException);
^~~~~
In file included from src/Client.cpp:25:0:
include/ClientImpl.h:74:48: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
InvocationResponse invoke(Procedure &proc) throw (Exception, NoConnectionsException, UninitializedParamsException, LibEventException);
^~~~~
include/ClientImpl.h:75:81: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void invoke(Procedure &proc, boost::shared_ptr<ProcedureCallback> callback) throw (Exception, NoConnectionsException, UninitializedParamsException, LibEventException, ElasticModeMismatchException);
^~~~~
include/ClientImpl.h:76:63: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void invoke(Procedure &proc, ProcedureCallback *callback) throw (Exception, NoConnectionsException, UninitializedParamsException, LibEventException, ElasticModeMismatchException);
^~~~~
include/ClientImpl.h:77:20: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void runOnce() throw (Exception, NoConnectionsException, LibEventException);
^~~~~
include/ClientImpl.h:78:16: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void run() throw (Exception, NoConnectionsException, LibEventException);
^~~~~
include/ClientImpl.h:88:18: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
bool drain() throw (Exception, NoConnectionsException, LibEventException);
^~~~~
include/ClientImpl.h:98:30: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void runTimeoutMonitor() throw (LibEventException);
^~~~~
include/ClientImpl.h:136:37: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecate ]
ClientImpl(ClientConfig config) throw (Exception, LibEventException, MDHashException, SSLException);
^~~~~
include/ClientImpl.h:138:108: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
itiateAuthentication(struct bufferevent *bev, const std::string& hostname, unsigned short port) throw (LibEventException);
^~~~~
include/ClientImpl.h:139:56: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecate ]
void finalizeAuthentication(PendingConnection* pc) throw (Exception, ConnectException);
^~~~~
include/ClientImpl.h:159:71: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecate ]
void initiateConnection(boost::shared_ptr<PendingConnection> &pc) throw (ConnectException, LibEventException, SSLException);
^~~~~
include/ClientImpl.h:176:52: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecate ]
void hashPassword(const std::string& password) throw (MDHashException);
^~~~~
include/ClientImpl.h:182:26: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecate ]
void initSslConext() throw (SSLException);
^~~~~
include/ClientImpl.h:202:39: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecate ]
void setUpTimeoutCheckerMonitor() throw (LibEventException);
^~~~~
include/ClientImpl.h:203:31: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecate ]
void startMonitorThread() throw (TimerThreadException);
^~~~~
src/Client.cpp:29:44: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
Client Client::create(ClientConfig config) throw (voltdb::Exception, voltdb::LibEventException) {
^~~~~
src/Client.cpp:41:58: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
const bool keepConnecting) throw (voltdb::Exception,
^~~~~
src/Client.cpp:54:52: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
InvocationResponse Client::invoke(Procedure &proc) throw (voltdb::Exception,
^~~~~
src/Client.cpp:62:68: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
boost::shared_ptr<ProcedureCallback> callback) throw (voltdb::Exception,
^~~~~
src/Client.cpp:70:50: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
ProcedureCallback *callback) throw (voltdb::Exception,
^~~~~
src/Client.cpp:77:24: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void Client::runOnce() throw (voltdb::Exception,
^~~~~
src/Client.cpp:83:20: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
void Client::run() throw (voltdb::Exception,
^~~~~
src/Client.cpp:89:22: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
bool Client::drain() throw (voltdb::Exception,
^~~~~
makefile:73: recipe for target 'obj/Client.o' failed
make: *** [obj/Client.o] Error 1