### PR TITLE
ENG-15036 add c-client to voltdb-client-cpp

### DIFF
--- a/README.build
+++ b/README.build
@@ -1,6 +1,6 @@
 Prerequisites
 
-Building the VoltDB CPP client from source requires the boost c++ development libraries. 
+Building the VoltDB CPP client from source requires the boost c++ development libraries.
 Version 1.54+ or better is recommended.
 
 Notes:
@@ -9,7 +9,7 @@ Notes:
     in the file name. If the libraries on your platform are not tagged, you will need to edit the makefile
     and remove the -mt tag. Alternatively you can create a soft link to the to the needed libraries using
     the tagged name referenced by the makefile.
-    
+
     If your platform's package manager does not provide the required version of boost you can build it from source
     using these commands:
 
@@ -46,7 +46,7 @@ version of libevent - simply replace the libevent tarball.
 Running the tests
 
 The tests require CPPUnit. You can install cppunit on ubuntu with the
-command: `apt get install libcppunit-dev`
+command: `apt-get install libcppunit-dev`
 
 Once you have built either version of the shared library you can build the
 tests using the makefile in Tests and then run the Tests executable that is

--- a/README.build
+++ b/README.build
@@ -1,26 +1,3 @@
-Prerequisites
-
-Building the VoltDB CPP client from source requires the boost c++ development libraries.
-Version 1.54+ or better is recommended.
-
-Notes:
-
-    On some platforms boost libraries are "tagged" with the feature support (such as -mt for multithreading)
-    in the file name. If the libraries on your platform are not tagged, you will need to edit the makefile
-    and remove the -mt tag. Alternatively you can create a soft link to the to the needed libraries using
-    the tagged name referenced by the makefile.
-
-    If your platform's package manager does not provide the required version of boost you can build it from source
-    using these commands:
-
-    wget http://sourceforge.net/projects/boost/files/boost/1.56.0/boost_1_56_0.tar.gz/download
-    tar -C /usr/local -xf boost_x_y_z.tar.gz
-    cd /usr/local/boost_x_y_z
-    ./bootstrap.sh --prefix=/usr/local
-    ./b2 --layout=tagged install
-    ln -s /usr/local/boost_x_y_z /usr/local/boost
-
-
 Building the client
 
 Running `make` produces the CPP client tarball that is available

--- a/README.md
+++ b/README.md
@@ -24,10 +24,15 @@ New Features in 8.4
 
 New Features in 7.1
 ==================
-- Add SSL support to C++ client to enable communication between VoltDB server and C++ client over SSL transport.
-To enable communication between a VoltDB server with SSL enabled for the external ports and a C++ client, the client
-needs to be instantiated using client config (voltdb::ClientConfig) with the ssl field (m_useSSL) set to true. Code
-snippet:
+
+- Add SSL support to C++ client to enable communication between VoltDB server
+  and C++ client over SSL transport.
+
+To enable communication between a VoltDB server with SSL enabled for the
+external ports and a C++ client, the client needs to be instantiated using
+client config (voltdb::ClientConfig) with the ssl field (m_useSSL) set to true.
+Code snippet:
+
 ```C++
 voltdb::ClientConfig config;
 ...
@@ -40,9 +45,13 @@ voltdb::Client client = voltdb::Client::create(config);
 New Features in 7.0
 ==================
 - Support for Table (synomous to VoltTable on server side) in parameter set.
-How to construct table: initialize table with column schema. Generate row to be inserted - initialize the row with same
-column schema as that of table, populate the row and add the row to the table. After inserting the populated row to the
-table, the row instance can be reused to populate it row with new values and push it table.
+
+How to construct table: initialize table with column schema. Generate row to be
+inserted - initialize the row with same column schema as that of table,
+populate the row and add the row to the table. After inserting the populated
+row to the table, the row instance can be reused to populate with new values
+and push to the table.
+
 ```C++
 std::vector<voltdb::Column> columns;
 columns.push_back(voltdb::Column("col1", voltdb::WIRE_TYPE_BIGINT));
@@ -58,7 +67,10 @@ table.addRow(row);
 
 New Features in V6.9
 ==================
-- Support for timing out outstanding/pending invocation requests. By default the monitoring of the pending requests for timeout is disabled. To exercise feature, timeout has to be enabled using client config. Default timeout is 10 seconds and can be tweaked through client config.
+- Support for timing out outstanding/pending invocation requests. By default
+  the monitoring of the pending requests for timeout is disabled. To exercise
+  feature, timeout has to be enabled using client config. Default timeout is 10
+  seconds and can be tweaked through client config.
 ```C++
 bool enableQueryTimeout = true;
 int queryTimeout = 10;
@@ -69,9 +81,16 @@ voltdb::Client client = voltdb::Client::create(config);
 
 New Features in V6.8
 ==================
-- Update backpressure notification to notify when backpressure on client transitions from on to off
-- Fix handling of pending connection logic where client gets disconnected and tries to reconnect, if socket timeout is longer than 10 seconds, it can potentially crash the client
-- Update setaffinity logic to not drop the set affinity request in case of backpresure with client configured with enable abandon set to true.
+
+- Update backpressure notification to notify when backpressure on client
+  transitions from on to off
+
+- Fix handling of pending connection logic where client gets disconnected and
+  tries to reconnect, if socket timeout is longer than 10 seconds, it can
+  potentially crash the client
+
+- Update setaffinity logic to not drop the set affinity request in case of
+  backpresure with client configured with enable abandon set to true.
 
 New Features in V6.0
 ==================

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ The Linux binary was compiled with GCC 4.4.7 on Centos 6.7.
 The OSX binary was compiled with Xcode 7.2 on OSX 10.11.
 
 The source code is available in the [VoltDB Github repository]
-(https://github.com/VoltDB/voltdb-client-cpp). 
+(https://github.com/VoltDB/voltdb-client-cpp).
+
+New Features in 8.4
+==================
+- Removed dependency on Boost library (by taking advantage of C++11 features)
 
 New Features in 7.1
 ==================
@@ -146,10 +150,9 @@ clientvoter.cpp                  \
 ./libevent_pthread.a             \
 -lrt                             \
 -pthread                         \
--lboost_system                   \
--lboost_thread                   \
 -o voter
 ```
 
 Note that -lrt should not be included for the mac edition. See the example makefile
 for more detail.
+

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ New Features in 8.4
 ==================
 - Removed dependency on Boost library (by taking advantage of C++11 features)
 
+- Added a C wrapper for a few functions to support synchronous execution of Ad-Hoc query.
+The wrapper can serve as a bridge to any client in most other programming languages.
+
 New Features in 7.1
 ==================
 

--- a/examples/AsyncHelloWorld.cpp
+++ b/examples/AsyncHelloWorld.cpp
@@ -25,7 +25,6 @@
 #define __STDC_LIMIT_MACROS
 
 #include <vector>
-#include <boost/shared_ptr.hpp>
 #include "Client.h"
 #include "Table.h"
 #include "TableIterator.h"
@@ -44,7 +43,7 @@ class CountingCallback : public voltdb::ProcedureCallback {
 public:
     CountingCallback(int32_t count) : m_count(count) {}
 
-    bool callback(voltdb::InvocationResponse response) throw (voltdb::Exception) {
+    bool callback(voltdb::InvocationResponse response) {
         m_count--;
 
         //Print the error response if there was a problem
@@ -69,7 +68,7 @@ private:
  */
 class PrintingCallback : public voltdb::ProcedureCallback {
 public:
-    bool callback(voltdb::InvocationResponse response) throw (voltdb::Exception) {
+    bool callback(voltdb::InvocationResponse response) {
         std::cout << response.toString();
         return true;
     }
@@ -93,7 +92,7 @@ int main(int argc, char **argv) {
     parameterTypes[2] = voltdb::Parameter(voltdb::WIRE_TYPE_STRING);
     voltdb::Procedure procedure("Insert", parameterTypes);
 
-    boost::shared_ptr<CountingCallback> callback(new CountingCallback(5));
+    std::shared_ptr<CountingCallback> callback(new CountingCallback(5));
 
     /*
      * Load the database.
@@ -130,7 +129,7 @@ int main(int argc, char **argv) {
      * Retrieve the message
      */
     selectProc.params()->addString("Spanish");
-    client.invoke(selectProc, boost::shared_ptr<PrintingCallback>(new PrintingCallback()));
+    client.invoke(selectProc, std::shared_ptr<PrintingCallback>(new PrintingCallback()));
 
     /*
      * Invoke event loop

--- a/examples/HelloWorld.cpp
+++ b/examples/HelloWorld.cpp
@@ -25,7 +25,6 @@
 #define __STDC_LIMIT_MACROS
 
 #include <vector>
-#include <boost/shared_ptr.hpp>
 #include "Client.h"
 #include "Table.h"
 #include "TableIterator.h"
@@ -34,6 +33,22 @@
 #include "Parameter.hpp"
 #include "ParameterSet.hpp"
 #include "ClientConfig.h"
+
+#include "CAPI.h"
+
+void print_result(c_stringified_tables* r) {
+   for(int tbl_index = 0; tbl_index < r->num_tables; ++tbl_index) {
+      std::cout<<tbl_index<<" th table:"<<std::endl;
+      const c_stringified_table& tbl = r->tables[tbl_index];
+      for(int row_index = 0; row_index < tbl.num_rows; ++row_index) {
+         for(int col_index = 0; col_index < tbl.num_cols; ++col_index) {
+            std::cout<<tbl.tuples[row_index][col_index]<<"\t";
+         }
+         std::cout<<std::endl;
+      }
+      std::cout<<std::endl;
+   }
+}
 
 int main(int argc, char **argv) {
     /*
@@ -51,6 +66,52 @@ int main(int argc, char **argv) {
     parameterTypes[0] = voltdb::Parameter(voltdb::WIRE_TYPE_STRING);
     parameterTypes[1] = voltdb::Parameter(voltdb::WIRE_TYPE_STRING);
     parameterTypes[2] = voltdb::Parameter(voltdb::WIRE_TYPE_STRING);
+    {
+
+       c_client client = c_create_client("myusername", "mypassword", "localhost", 21212, false,
+             /*voltdb::HASH_SHA1,*/ false, false, 10, false);
+       c_procedure adhoc = c_create_call();
+       std::vector<std::string> queries{
+          "DROP TABLE foo IF EXISTS;",
+          "CREATE TABLE foo(i int);",
+          "INSERT INTO foo VALUES(12);",
+          "INSERT INTO foo VALUES(14);",
+          "INSERT INTO foo VALUES(18);",
+          "SELECT * FROM foo LIMIT 5;"
+       };
+       for (std::string const& s : queries) {
+          const char* params[] = {s.c_str(), nullptr};
+          voltdb::InvocationResponse response = c_exec_proc(&client, &adhoc, params).response;
+          if (response.failure()) { std::cout <<response.toString() << std::endl; return -1; }
+       }
+       const char* params[] = {queries[5].c_str(), nullptr};
+       c_invocation_response response = c_exec_proc(&client, &adhoc, params);
+       c_stringified_tables result = c_exec_result(&response);
+       print_result(&result);
+       c_destroy_result(&result);
+       c_drop_procedure(&adhoc);
+       c_close(&client);
+
+       /*
+          voltdb::Procedure adhoc("@AdHoc", std::vector<voltdb::Parameter>(1, voltdb::WIRE_TYPE_STRING));
+          voltdb::ParameterSet* params = adhoc.params();
+
+          params->addString("CREATE TABLE foo (i int);");
+          voltdb::InvocationResponse response = client.invoke(adhoc);
+          if (response.failure()) { std::cout <<response.toString() << std::endl; return -1; }
+
+          params->addString("INSERT INTO foo VALUES(12);");
+          response = client.invoke(adhoc);
+          if (response.failure()) { std::cout <<response.toString() << std::endl; return -1; }
+
+          params->addString("SELECT * from foo LIMIT 5;");
+          response = client.invoke(adhoc);
+          if (response.failure()) { std::cout <<response.toString() << std::endl; return -1; }
+          std::cout << response.toString();
+          return 0;
+          */
+
+    }
     voltdb::Procedure procedure("Insert", parameterTypes);
 
     voltdb::InvocationResponse response;

--- a/examples/SSLVoter.cpp
+++ b/examples/SSLVoter.cpp
@@ -32,7 +32,6 @@
 #include <time.h>
 #include <algorithm>
 #include <sys/time.h>
-#include <boost/shared_ptr.hpp>
 #include "Client.h"
 #include "Table.h"
 #include "TableIterator.h"
@@ -72,8 +71,7 @@ int64_t millisec_time() {
 class VoterCallback : public voltdb::ProcedureCallback
 {
 public:
-    bool callback(voltdb::InvocationResponse response) throw (voltdb::Exception)
-    {
+    bool callback(voltdb::InvocationResponse response) {
         bool retVal = false;
         if (response.failure())
         {
@@ -202,7 +200,7 @@ int main(int argc, char* argv[]) {
     parameterTypes.clear();
     parameterTypes.resize(3);
 
-    boost::shared_ptr<VoterCallback> callback(new VoterCallback());
+    std::shared_ptr<VoterCallback> callback(new VoterCallback());
 
     while (endTime > currentTime)
     {

--- a/examples/Voter.cpp
+++ b/examples/Voter.cpp
@@ -32,7 +32,6 @@
 #include <time.h>
 #include <algorithm>
 #include <sys/time.h>
-#include <boost/shared_ptr.hpp>
 #include "Client.h"
 #include "Table.h"
 #include "TableIterator.h"
@@ -41,8 +40,6 @@
 #include "Parameter.hpp"
 #include "ParameterSet.hpp"
 #include "ProcedureCallback.hpp"
-
-//#include <boost/date_time/posix_time/posix_time.hpp>
 
 using namespace std;
 
@@ -71,8 +68,7 @@ int64_t millisec_time() {
 class VoterCallback : public voltdb::ProcedureCallback
 {
 public:
-	bool callback(voltdb::InvocationResponse response) throw (voltdb::Exception)
-	{
+	bool callback(voltdb::InvocationResponse response) {
 		bool retVal = false;
 		if (response.failure())
 		{
@@ -194,7 +190,7 @@ int main(int argc, char* argv[])
 	parameterTypes.clear();
 	parameterTypes.resize(3);
 
-	boost::shared_ptr<VoterCallback> callback(new VoterCallback());
+	std::shared_ptr<VoterCallback> callback(new VoterCallback());
 
 	while (endTime > currentTime)
 	{

--- a/examples/makefile
+++ b/examples/makefile
@@ -2,48 +2,45 @@ VOLT_INCLUDEDIR=..
 VOLT_LIBDIR=..
 VOLT_LIBS=$(VOLT_LIBDIR)
 VOLT_INCLUDES=-I$(VOLT_INCLUDEDIR)/include
-CC=g++
 RM=rm -rf
-OPTIMIZATION=-O3
-CFLAGS=$(BOOST_INCLUDES) $(VOLT_INCLUDES) -g3 ${OPTIMIZATION}
-CFLAGS += -fPIC
+CXXFLAGS=$(VOLT_INCLUDES) -std=c++11 -g3 -O3 -fPIC
 
 PLATFORM = $(shell uname)
 ifeq ($(PLATFORM),Darwin)
-    BOOST_INCLUDES=-I/usr/local/include
-    BOOST_LIBS=-L/usr/local/lib
-    SYSTEM_LIBS := -lpthread $(BOOST_LIBS) -lboost_system-mt -lboost_thread-mt
-    THIRD_PARTY_DIR := $(VOLT_LIBS)/third_party_libs/osx
-    THIRD_PARTY_LIBS := $(THIRD_PARTY_DIR)/libevent.a \
-                        $(THIRD_PARTY_DIR)/libevent_openssl.a \
-                        $(THIRD_PARTY_DIR)/libevent_pthreads.a \
-                        $(THIRD_PARTY_DIR)/libssl.a \
-                        $(THIRD_PARTY_DIR)/libcrypto.a
-endif
-ifeq ($(PLATFORM),Linux)
-    THIRD_PARTY_DIR := $(VOLT_LIBS)/third_party_libs/linux
-    THIRD_PARTY_LIBS := $(THIRD_PARTY_DIR)/libevent.a \
-                        $(THIRD_PARTY_DIR)/libevent_openssl.a \
-                        $(THIRD_PARTY_DIR)/libevent_pthreads.a \
-                        $(THIRD_PARTY_DIR)/libssl.a \
-                        $(THIRD_PARTY_DIR)/libcrypto.a \
-                        -ldl
-    SYSTEM_LIBS := -lpthread -lrt -lboost_system -lboost_thread
+	  THIRD_PARTY_DIR := $(VOLT_LIBS)/third_party_libs/osx
+	  THIRD_PARTY_LIBS := $(THIRD_PARTY_DIR)/libevent.a \
+		    $(THIRD_PARTY_DIR)/libevent_openssl.a \
+		    $(THIRD_PARTY_DIR)/libevent_pthreads.a \
+		    $(THIRD_PARTY_DIR)/libssl.a \
+		    $(THIRD_PARTY_DIR)/libcrypto.a
+	  SYSTEM_LIBS := -lpthread
+else ifeq ($(PLATFORM),Linux)
+	  THIRD_PARTY_DIR := $(VOLT_LIBS)/third_party_libs/linux
+	  THIRD_PARTY_LIBS := $(THIRD_PARTY_DIR)/libevent.a \
+		    $(THIRD_PARTY_DIR)/libevent_openssl.a \
+		    $(THIRD_PARTY_DIR)/libevent_pthreads.a \
+		    $(THIRD_PARTY_DIR)/libssl.a \
+		    $(THIRD_PARTY_DIR)/libcrypto.a \
+		    -ldl
+	  SYSTEM_LIBS := -lpthread -lrt
+else
+	  $(error "Unsupported platform $(PLATFORM)")
 endif
 
 all: helloworld asynchelloworld voter sslvoter
 
 asynchelloworld: AsyncHelloWorld.cpp $(VOLT_LIBS)/libvoltdbcpp.a
-	$(CC) $(CFLAGS) AsyncHelloWorld.cpp $(VOLT_LIBS)/libvoltdbcpp.a $(THIRD_PARTY_LIBS) $(SYSTEM_LIBS) -o asynchelloworld
+	$(CXX) $(CXXFLAGS) AsyncHelloWorld.cpp $(VOLT_LIBS)/libvoltdbcpp.a $(THIRD_PARTY_LIBS) $(SYSTEM_LIBS) -o asynchelloworld
 
 helloworld: HelloWorld.cpp $(VOLT_LIBS)/libvoltdbcpp.a
-	$(CC) $(CFLAGS) HelloWorld.cpp $(VOLT_LIBS)/libvoltdbcpp.a $(THIRD_PARTY_LIBS) $(SYSTEM_LIBS) -o helloworld
+	$(CXX) $(CXXFLAGS) HelloWorld.cpp $(VOLT_LIBS)/libvoltdbcpp.a $(THIRD_PARTY_LIBS) $(SYSTEM_LIBS) -o helloworld
 
 voter: Voter.cpp $(VOLT_LIBS)/libvoltdbcpp.a
-	$(CC) $(CFLAGS) Voter.cpp $(VOLT_LIBS)/libvoltdbcpp.a $(THIRD_PARTY_LIBS) $(SYSTEM_LIBS) -o voter
+	$(CXX) $(CXXFLAGS) Voter.cpp $(VOLT_LIBS)/libvoltdbcpp.a $(THIRD_PARTY_LIBS) $(SYSTEM_LIBS) -o voter
 
 sslvoter: SSLVoter.cpp $(VOLT_LIBS)/libvoltdbcpp.a
-	$(CC) $(CFLAGS) SSLVoter.cpp $(VOLT_LIBS)/libvoltdbcpp.a $(THIRD_PARTY_LIBS) $(SYSTEM_LIBS) -o sslvoter
+	$(CXX) $(CXXFLAGS) SSLVoter.cpp $(VOLT_LIBS)/libvoltdbcpp.a $(THIRD_PARTY_LIBS) $(SYSTEM_LIBS) -o sslvoter
 
 clean:
 	$(RM) asynchelloworld helloworld voter sslvoter *.dSYM *~
+

--- a/include/ByteBuffer.hpp
+++ b/include/ByteBuffer.hpp
@@ -126,22 +126,22 @@ public:
         return *this;
     }
 
-    void get(char *storage, int32_t length) throw (OverflowUnderflowException) {
+    void get(char *storage, int32_t length) {
         ::memcpy(storage, &m_buffer[checkGetPutIndex(length)], static_cast<uint32_t>(length));
     }
-    void get(int32_t index, char *storage, int32_t length) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
+    void get(int32_t index, char *storage, int32_t length) {
         ::memcpy(storage, &m_buffer[checkIndex(index, length)], static_cast<uint32_t>(length));
     }
-    ByteBuffer& put(const char *storage, int32_t length) throw (OverflowUnderflowException) {
+    ByteBuffer& put(const char *storage, int32_t length) {
         ::memcpy(&m_buffer[checkGetPutIndex(length)], storage, static_cast<uint32_t>(length));
         return *this;
     }
-    ByteBuffer& put(int32_t index, const char *storage, int32_t length) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
+    ByteBuffer& put(int32_t index, const char *storage, int32_t length) {
         ::memcpy(&m_buffer[checkIndex(index, length)], storage, static_cast<uint32_t>(length));
         return *this;
     }
 
-    ByteBuffer& put(ByteBuffer *other) throw (OverflowUnderflowException) {
+    ByteBuffer& put(ByteBuffer *other) {
         int32_t oremaining = other->remaining();
         if (oremaining == 0) {
             return *this;
@@ -152,79 +152,79 @@ public:
         return *this;
     }
 
-    int8_t getInt8() throw (OverflowUnderflowException) {
+    int8_t getInt8() {
         return m_buffer[checkGetPutIndex(1)];
     }
-    int8_t getInt8(int32_t index) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
+    int8_t getInt8(int32_t index) {
         return m_buffer[checkIndex( index, 1)];
     }
-    ByteBuffer& putInt8(int8_t value) throw (OverflowUnderflowException) {
+    ByteBuffer& putInt8(int8_t value) {
         m_buffer[checkGetPutIndex(1)] = value;
         return *this;
     }
-    ByteBuffer& putInt8(int32_t index, int8_t value) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
+    ByteBuffer& putInt8(int32_t index, int8_t value) {
         m_buffer[checkIndex( index, 1)] = value;
         return *this;
     }
 
-    int16_t getInt16() throw (OverflowUnderflowException) {
+    int16_t getInt16() {
         int16_t value;
         ::memcpy( &value, &m_buffer[checkGetPutIndex(2)], 2);
         return static_cast<int16_t>(ntohs(value));
     }
-    int16_t getInt16(int32_t index) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
+    int16_t getInt16(int32_t index) {
         int16_t value;
         ::memcpy( &value, &m_buffer[checkIndex(index, 2)], 2);
         return static_cast<int16_t>(ntohs(value));
     }
-    ByteBuffer& putInt16(int16_t value) throw (OverflowUnderflowException) {
+    ByteBuffer& putInt16(int16_t value) {
         *reinterpret_cast<uint16_t*>(&m_buffer[checkGetPutIndex(2)]) = htons(value);
         return *this;
     }
-    ByteBuffer& putInt16(int32_t index, int16_t value) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
+    ByteBuffer& putInt16(int32_t index, int16_t value) {
         *reinterpret_cast<uint16_t*>(&m_buffer[checkIndex(index, 2)]) = htons(value);
         return *this;
     }
 
-    int32_t getInt32() throw (OverflowUnderflowException) {
+    int32_t getInt32() {
         uint32_t value;
         ::memcpy( &value, &m_buffer[checkGetPutIndex(4)], 4);
         return static_cast<int32_t>(ntohl(value));
     }
-    int32_t getInt32(int32_t index) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
+    int32_t getInt32(int32_t index) {
         uint32_t value;
         ::memcpy( &value, &m_buffer[checkIndex(index, 4)], 4);
         return static_cast<int32_t>(ntohl(value));
     }
-    ByteBuffer& putInt32(int32_t value) throw (OverflowUnderflowException) {
+    ByteBuffer& putInt32(int32_t value) {
         *reinterpret_cast<uint32_t*>(&m_buffer[checkGetPutIndex(4)]) = htonl(static_cast<uint32_t>(value));
         return *this;
     }
-    ByteBuffer& putInt32(int32_t index, int32_t value) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
+    ByteBuffer& putInt32(int32_t index, int32_t value) {
         *reinterpret_cast<uint32_t*>(&m_buffer[checkIndex(index, 4)]) = htonl(static_cast<uint32_t>(value));
         return *this;
     }
 
-    int64_t getInt64() throw (OverflowUnderflowException) {
+    int64_t getInt64() {
         uint64_t value;
         ::memcpy( &value, &m_buffer[checkGetPutIndex(8)], 8);
         return static_cast<int64_t>(ntohll(value));
     }
-    int64_t getInt64(int32_t index) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
+    int64_t getInt64(int32_t index) {
         uint64_t value;
         ::memcpy( &value, &m_buffer[checkIndex(index, 8)], 8);
         return static_cast<int64_t>(ntohll(value));
     }
-    ByteBuffer& putInt64(int64_t value) throw (OverflowUnderflowException) {
+    ByteBuffer& putInt64(int64_t value) {
         *reinterpret_cast<uint64_t*>(&m_buffer[checkGetPutIndex(8)]) = htonll(static_cast<uint64_t>(value));
         return *this;
     }
-    ByteBuffer& putInt64(int32_t index, int64_t value) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
+    ByteBuffer& putInt64(int32_t index, int64_t value) {
         *reinterpret_cast<uint64_t*>(&m_buffer[checkIndex(index, 8)]) = htonll(static_cast<uint64_t>(value));
         return *this;
     }
 
-    double getDouble() throw (OverflowUnderflowException) {
+    double getDouble() {
         uint64_t value;
         ::memcpy( &value, &m_buffer[checkGetPutIndex(8)], 8);
         value = ntohll(value);
@@ -232,7 +232,7 @@ public:
         ::memcpy( &retval, &value, 8);
         return retval;
     }
-    double getDouble(int32_t index) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
+    double getDouble(int32_t index) {
         uint64_t value;
         ::memcpy( &value, &m_buffer[checkIndex(index, 8)], 8);
         value = ntohll(value);
@@ -240,14 +240,14 @@ public:
         ::memcpy( &retval, &value, 8);
         return retval;
     }
-    ByteBuffer& putDouble(double value) throw (OverflowUnderflowException) {
+    ByteBuffer& putDouble(double value) {
         uint64_t newval;
         ::memcpy(&newval, &value, 8);
         newval = htonll(newval);
         *reinterpret_cast<uint64_t*>(&m_buffer[checkGetPutIndex(8)]) = newval;
         return *this;
     }
-    ByteBuffer& putDouble(int32_t index, double value) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
+    ByteBuffer& putDouble(int32_t index, double value) {
         uint64_t newval;
         ::memcpy(&newval, &value, 8);
         newval = htonll(newval);
@@ -255,7 +255,7 @@ public:
         return *this;
     }
 
-    std::string getString(bool &wasNull) throw (OverflowUnderflowException) {
+    std::string getString(bool &wasNull) {
         int32_t length = getInt32();
         if (length == -1) {
             wasNull = true;
@@ -264,7 +264,7 @@ public:
         char *data = getByReference(length);
         return std::string(data, static_cast<uint32_t>(length));
     }
-    std::string getString(int32_t index, bool &wasNull) throw (OverflowUnderflowException, IndexOutOfBoundsException) {
+    std::string getString(int32_t index, bool &wasNull) {
         int32_t length = getInt32(index);
         if (length == -1) {
             wasNull = true;
@@ -274,8 +274,7 @@ public:
         return std::string(data, static_cast<uint32_t>(length));
     }
 
-    bool getBytes(bool &wasNull, int32_t bufsize, uint8_t *out_value, int32_t *out_len)
-    throw (OverflowUnderflowException) {
+    bool getBytes(bool &wasNull, int32_t bufsize, uint8_t *out_value, int32_t *out_len) {
         int32_t length = getInt32();
         *out_len = length;
         if (length == -1) {
@@ -288,8 +287,7 @@ public:
         memcpy(out_value, data, length);
         return true;
     }
-    bool getBytes(int32_t index, bool &wasNull, const int32_t bufsize, uint8_t *out_value, int32_t *out_len)
-    throw (OverflowUnderflowException, IndexOutOfBoundsException) {
+    bool getBytes(int32_t index, bool &wasNull, const int32_t bufsize, uint8_t *out_value, int32_t *out_len) {
         int32_t length = getInt32(index);
         *out_len = length;
         if (length == -1) {
@@ -302,35 +300,31 @@ public:
         memcpy(out_value, data, length);
         return true;
     }
-    ByteBuffer& putBytes(const int32_t bufsize, const uint8_t *in_value)
-    throw (OverflowUnderflowException) {
+    ByteBuffer& putBytes(const int32_t bufsize, const uint8_t *in_value) {
         assert(in_value  || bufsize==0);
         putInt32(bufsize);
         put((const char*)in_value, bufsize);
         return *this;
     }
-    ByteBuffer& putBytes(int32_t index, const int32_t bufsize, const uint8_t *in_value)
-    throw (OverflowUnderflowException, IndexOutOfBoundsException) {
+    ByteBuffer& putBytes(int32_t index, const int32_t bufsize, const uint8_t *in_value) {
         assert(in_value  || bufsize==0);
         putInt32(index, bufsize);
         put(index + 4, (const char*)in_value, bufsize);
         return *this;
     }
 
-    ByteBuffer& putString(const std::string& value)
-    throw (OverflowUnderflowException) {
+    ByteBuffer& putString(const std::string& value) {
         return putBytes(static_cast<int32_t>(value.size()), (const uint8_t*)value.data());
     }
 
-    ByteBuffer& putString(int32_t index, const std::string& value)
-    throw (OverflowUnderflowException, IndexOutOfBoundsException) {
+    ByteBuffer& putString(int32_t index, const std::string& value) {
         return putBytes(index, static_cast<int32_t>(value.size()), (const uint8_t*)value.data());
     }
 
     int32_t position() const {
         return m_position;
     }
-    ByteBuffer& position(int32_t position) throw (IndexOutOfBoundsException) {
+    ByteBuffer& position(int32_t position) {
         m_position = checkIndex(position, 0);
         return *this;
     }
@@ -346,7 +340,7 @@ public:
         return m_limit;
     }
 
-    ByteBuffer& limit(int32_t newLimit) throw (IndexOutOfBoundsException) {
+    ByteBuffer& limit(int32_t newLimit) {
         if (newLimit > m_capacity || newLimit < 0) {
             throw IndexOutOfBoundsException();
         }
@@ -368,19 +362,19 @@ public:
         return false;
     }
 
-    virtual void ensureRemaining(int32_t remaining) throw(NonExpandableBufferException) {
+    virtual void ensureRemaining(int32_t remaining) {
         remaining = 0;
         throw NonExpandableBufferException();
     }
-    virtual void ensureRemainingExact(int32_t remaining) throw(NonExpandableBufferException) {
+    virtual void ensureRemainingExact(int32_t remaining) {
         remaining = 0;
         throw NonExpandableBufferException();
     }
-    virtual void ensureCapacity(int32_t capacity) throw(NonExpandableBufferException) {
+    virtual void ensureCapacity(int32_t capacity) {
         capacity = 0;
         throw NonExpandableBufferException();
     }
-    virtual void ensureCapacityExact(int32_t capacity) throw(NonExpandableBufferException) {
+    virtual void ensureCapacityExact(int32_t capacity) {
         capacity = 0;
         throw NonExpandableBufferException();
     }
@@ -447,17 +441,17 @@ protected:
 
 class ExpandableByteBuffer : public ByteBuffer {
 public:
-    void ensureRemaining(int32_t amount)  throw(NonExpandableBufferException) {
+    void ensureRemaining(int32_t amount) {
         if (remaining() < amount) {
             ensureCapacity(position() + amount);
         }
     }
-    void ensureRemainingExact(int32_t amount)  throw(NonExpandableBufferException) {
+    void ensureRemainingExact(int32_t amount) {
         if (remaining() < amount) {
             ensureCapacityExact(position() + amount);
         }
     }
-    void ensureCapacity(int32_t capacity)  throw(NonExpandableBufferException) {
+    void ensureCapacity(int32_t capacity) {
         if (m_capacity < capacity) {
             int32_t newCapacity = m_capacity;
             while (newCapacity < capacity) {
@@ -472,7 +466,7 @@ public:
         }
     }
 
-    void ensureCapacityExact(int32_t capacity)  throw(NonExpandableBufferException) {
+    void ensureCapacityExact(int32_t capacity) {
         if (m_capacity < capacity) {
             char *newBuffer = new char[capacity];
             ::memcpy(newBuffer, m_buffer, static_cast<uint32_t>(m_position));

--- a/include/ByteBuffer.hpp
+++ b/include/ByteBuffer.hpp
@@ -50,8 +50,6 @@
 
 #include <stdint.h>
 #include <arpa/inet.h>
-#include <boost/shared_array.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/scoped_array.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <vector>
@@ -513,15 +511,15 @@ public:
     }
 
     SharedByteBuffer(char *data, int32_t length) : ExpandableByteBuffer(data, length), m_ref(data) {}
-    SharedByteBuffer(boost::shared_array<char>& data, int32_t length) : ExpandableByteBuffer(data.get(), length), m_ref(data) {}
+    SharedByteBuffer(std::shared_ptr<char[]>& data, int32_t length) : ExpandableByteBuffer(data.get(), length), m_ref(data) {}
 
 protected:
     void resetRef(char *data)  {
         m_ref.reset(data);
     }
 private:
-    SharedByteBuffer(boost::shared_array<char> ref, char *data, int32_t length) : ExpandableByteBuffer(data, length), m_ref(ref) {}
-    boost::shared_array<char> m_ref;
+    SharedByteBuffer(std::shared_ptr<char[]> ref, char *data, int32_t length) : ExpandableByteBuffer(data, length), m_ref(ref) {}
+    std::shared_ptr<char[]> m_ref;
 };
 
 class ScopedByteBuffer : public ExpandableByteBuffer {

--- a/include/ByteBuffer.hpp
+++ b/include/ByteBuffer.hpp
@@ -48,10 +48,10 @@
 #ifndef VOLTDB_BYTEBUFFER_H
 #define VOLTDB_BYTEBUFFER_H
 
-#include <stdint.h>
+#include <cassert>
+#include <cstdint>
 #include <arpa/inet.h>
-#include <boost/scoped_array.hpp>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include <vector>
 #include <string>
 #include <cstring>
@@ -541,6 +541,7 @@ public:
 //
 //        return out(copy, length);
 //    }
+    ScopedByteBuffer(const ScopedByteBuffer &other) : ExpandableByteBuffer(other) { }
 protected:
     void resetRef(char *data)  {
         m_ref.reset(data);
@@ -550,10 +551,8 @@ private:
         assert(other.m_buffer != NULL);
         return *this;
     }
-    ScopedByteBuffer(const ScopedByteBuffer &other) : ExpandableByteBuffer(other) {
-    }
     ScopedByteBuffer() : ExpandableByteBuffer(), m_ref()  {};
-    boost::scoped_array<char> m_ref;
+    std::unique_ptr<char[]> m_ref;
 };
 
 //

--- a/include/CAPI.h
+++ b/include/CAPI.h
@@ -2,45 +2,39 @@
 #include "ClientConfig.h"
 #include "Client.h"
 
+#ifdef __cplusplus
 extern "C" {
-   struct c_client{
-      voltdb::ClientConfig* client_config;
-      voltdb::Client* client;
-   };
+#endif
+   struct c_client;
+   struct c_procedure;
+   struct c_invocation_response;
 
-   c_client c_create_client(const char* usrname, const char* pwd, const char* hostname,
+   struct c_client* c_create_client(const char* usrname, const char* pwd, const char* hostname,
          unsigned short port, bool keepConnecting, /*voltdb::ClientAuthHashScheme schema,*/
          bool enableAbandon, bool enableTimeout, int timeoutInSec, bool useSSL);
 
-   void c_close(c_client* config);
+   void c_close(struct c_client* config);
 
-   struct c_procedure {
-      voltdb::Procedure* procedure;
-      int numParams;
-      std::vector<voltdb::Parameter> parameters;
-   };
-
-   c_procedure c_create_procedure(const char* name, int nparams, voltdb::Parameter* params);
-   c_procedure c_create_call();
+   struct c_procedure* c_create_call();
    void c_drop_procedure(c_procedure*);
 
-   struct c_invocation_response {
-      voltdb::InvocationResponse response;
-   };
-
-   c_invocation_response c_exec_proc(c_client* client, c_procedure* proc, const char** params);
-   int c_status_code(c_invocation_response*);
+   struct c_invocation_response* c_exec_proc(struct c_client* client, struct c_procedure* proc, const char** params);
+   struct c_invocation_response* c_exec_adhoc(struct c_client* client, struct c_procedure* proc, const char* param);
+   int c_status_code(struct c_invocation_response*);
+   void c_destroy_response(struct c_invocation_response*);
 
    struct c_stringified_table {
       int num_cols, num_rows;
       char*** tuples;
    };
 
-   struct c_stringified_tables{
+   struct c_stringified_tables {
       int num_tables;
       c_stringified_table* tables;
    };
 
-   c_stringified_tables c_exec_result(c_invocation_response*);
-   void c_destroy_result(c_stringified_tables*);
+   c_stringified_tables* c_exec_result(struct c_invocation_response*);
+   void c_destroy_result(struct c_stringified_tables*);
+#ifdef __cplusplus
 }
+#endif

--- a/include/CAPI.h
+++ b/include/CAPI.h
@@ -1,0 +1,46 @@
+#pragma once
+#include "ClientConfig.h"
+#include "Client.h"
+
+extern "C" {
+   struct c_client{
+      voltdb::ClientConfig* client_config;
+      voltdb::Client* client;
+   };
+
+   c_client c_create_client(const char* usrname, const char* pwd, const char* hostname,
+         unsigned short port, bool keepConnecting, /*voltdb::ClientAuthHashScheme schema,*/
+         bool enableAbandon, bool enableTimeout, int timeoutInSec, bool useSSL);
+
+   void c_close(c_client* config);
+
+   struct c_procedure {
+      voltdb::Procedure* procedure;
+      int numParams;
+      std::vector<voltdb::Parameter> parameters;
+   };
+
+   c_procedure c_create_procedure(const char* name, int nparams, voltdb::Parameter* params);
+   c_procedure c_create_call();
+   void c_drop_procedure(c_procedure*);
+
+   struct c_invocation_response {
+      voltdb::InvocationResponse response;
+   };
+
+   c_invocation_response c_exec_proc(c_client* client, c_procedure* proc, const char** params);
+   int c_status_code(c_invocation_response*);
+
+   struct c_stringified_table {
+      int num_cols, num_rows;
+      char*** tuples;
+   };
+
+   struct c_stringified_tables{
+      int num_tables;
+      c_stringified_table* tables;
+   };
+
+   c_stringified_tables c_exec_result(c_invocation_response*);
+   void c_destroy_result(c_stringified_tables*);
+}

--- a/include/Client.h
+++ b/include/Client.h
@@ -28,7 +28,6 @@
 #include "Procedure.hpp"
 #include "StatusListener.h"
 #include "ClientLogger.h"
-#include <boost/shared_ptr.hpp>
 #include "ClientConfig.h"
 #include "Exception.hpp"
 
@@ -81,9 +80,9 @@ public:
      * @throws LibEventException An unknown error occured in libevent
      */
 #ifdef SWIG
-%ignore invoke(voltdb::Procedure &proc, boost::shared_ptr<voltdb::ProcedureCallback> callback);
+%ignore invoke(voltdb::Procedure &proc, std::shared_ptr<voltdb::ProcedureCallback> callback);
 #endif
-    void invoke(voltdb::Procedure &proc, boost::shared_ptr<voltdb::ProcedureCallback> callback);
+    void invoke(voltdb::Procedure &proc, std::shared_ptr<voltdb::ProcedureCallback> callback);
 
     /*
      * Asynchronously invoke a stored procedure. Returns immediately if there is no backpressure, but if there is
@@ -199,7 +198,7 @@ private:
     //Actual constructor
     Client(ClientImpl *m_impl);
 
-    boost::shared_ptr<ClientImpl> m_impl;
+    std::shared_ptr<ClientImpl> m_impl;
 };
 
 }

--- a/include/Client.h
+++ b/include/Client.h
@@ -55,7 +55,7 @@ public:
      * @throws voltdb::ConnectException An error occurs connecting or authenticating
      * @throws voltdb::LibEventException libevent returns an error code
      */
-    void createConnection(const std::string &hostname, const unsigned short port = 21212, const bool keepConnecting = false) throw (voltdb::ConnectException, voltdb::LibEventException, voltdb::Exception);
+    void createConnection(const std::string &hostname, const unsigned short port = 21212, const bool keepConnecting = false);
 
     /*
      * Close client connection.
@@ -69,7 +69,7 @@ public:
      * @throws UninitializedParamsException Some or all of the parameters for the stored procedure were not set
      * @throws LibEventException An unknown error occured in libevent
      */
-    voltdb::InvocationResponse invoke(voltdb::Procedure &proc) throw (voltdb::NoConnectionsException, voltdb::UninitializedParamsException, voltdb::LibEventException, voltdb::Exception);
+    voltdb::InvocationResponse invoke(voltdb::Procedure &proc);
 
     /*
      * Asynchronously invoke a stored procedure. Returns immediately if there is no backpressure, but if there is
@@ -83,7 +83,7 @@ public:
 #ifdef SWIG
 %ignore invoke(voltdb::Procedure &proc, boost::shared_ptr<voltdb::ProcedureCallback> callback);
 #endif
-    void invoke(voltdb::Procedure &proc, boost::shared_ptr<voltdb::ProcedureCallback> callback) throw (voltdb::NoConnectionsException, voltdb::UninitializedParamsException, voltdb::LibEventException, voltdb::Exception);
+    void invoke(voltdb::Procedure &proc, boost::shared_ptr<voltdb::ProcedureCallback> callback);
 
     /*
      * Asynchronously invoke a stored procedure. Returns immediately if there is no backpressure, but if there is
@@ -94,7 +94,7 @@ public:
      * @throws UninitializedParamsException Some or all of the parameters for the stored procedure were not set
      * @throws LibEventException An unknown error occured in libevent
      */
-    void invoke(voltdb::Procedure &proc, voltdb::ProcedureCallback *callback) throw (voltdb::NoConnectionsException, voltdb::UninitializedParamsException, voltdb::LibEventException, voltdb::Exception);
+    void invoke(voltdb::Procedure &proc, voltdb::ProcedureCallback *callback);
 
     /*
      * Run the event loop once and process pending events. This writes requests to any ready connections
@@ -103,7 +103,7 @@ public:
      * @throws NoConnectionsException No connections to the database so there is no work to be done
      * @throws LibEventException An unknown error occured in libevent
      */
-    void runOnce() throw (voltdb::NoConnectionsException, voltdb::LibEventException, voltdb::Exception);
+    void runOnce();
 
     /*
      * Enter the event loop and process pending events indefinitely. This writes requests to any ready connections
@@ -112,7 +112,7 @@ public:
      * @throws NoConnectionsException No connections to the database so there is no work to be done
      * @throws LibEventException An unknown error occured in libevent
      */
-    void run() throw (voltdb::NoConnectionsException, voltdb::LibEventException, voltdb::Exception);
+    void run();
 
     /*
      * Enter the event loop and process pending events until the specified time in microseconds has expired.
@@ -121,7 +121,7 @@ public:
      * @throws NoConnectionsException No connections to the database so there is no work to be done
      * @throws LibEventException An unknown error occured in libevent
      */
-    void runForMaxTime(uint64_t microseconds) throw (voltdb::NoConnectionsException, voltdb::LibEventException, voltdb::Exception);
+    void runForMaxTime(uint64_t microseconds);
 
     /*
      * Enter the event loop and process pending events until all responses have been received and then return.
@@ -131,7 +131,7 @@ public:
      * @throws LibEventException An unknown error occured in libevent
      * @return true if all requests were drained and false otherwise
      */
-    bool drain() throw (voltdb::NoConnectionsException, voltdb::LibEventException, voltdb::Exception);
+    bool drain();
 
     /*
      * Returns true if this client is draining; i.e., still processing
@@ -165,7 +165,7 @@ public:
     /*
      * Create a client with the specified configuration
      */
-    static Client create(voltdb::ClientConfig config = voltdb::ClientConfig()) throw(voltdb::LibEventException, voltdb::Exception);
+    static Client create(voltdb::ClientConfig config = voltdb::ClientConfig());
 
     /*
      * API to be called to enable client affinity (transaction homing)
@@ -194,7 +194,7 @@ private:
     /*
      * Disable various constructors and assignment
      */
-    Client() throw(voltdb::LibEventException);
+    Client();
 
     //Actual constructor
     Client(ClientImpl *m_impl);

--- a/include/Client.h
+++ b/include/Client.h
@@ -188,15 +188,15 @@ public:
     int64_t getExpiredRequestsCount() const;
 
     ~Client();
+
+    //Actual constructor
+    Client(ClientImpl *m_impl);
 private:
 
     /*
      * Disable various constructors and assignment
      */
     Client();
-
-    //Actual constructor
-    Client(ClientImpl *m_impl);
 
     std::shared_ptr<ClientImpl> m_impl;
 };

--- a/include/ClientConfig.h
+++ b/include/ClientConfig.h
@@ -36,7 +36,7 @@ public:
             std::string username = std::string(""),
             std::string password = std::string(""),
             ClientAuthHashScheme scheme = HASH_SHA1, bool enableAbandon = false,
-            bool enableQueryTimeout = false, int timeoutInSec =  DEFAULT_QUERY_TIMEOUT_SEC,
+            bool enableQueryTimeout = false, int timeoutInSec = DEFAULT_QUERY_TIMEOUT_SEC,
             bool useSSL = false);
 
     ClientConfig(
@@ -59,8 +59,8 @@ public:
     std::shared_ptr<StatusListener> m_listener;
     int32_t m_maxOutstandingRequests;
     ClientAuthHashScheme m_hashScheme;
-    bool m_enableAbandon;
-    bool m_enableQueryTimeout;
+    const bool m_enableAbandon;
+    const bool m_enableQueryTimeout;
     timeval m_queryTimeout;
     timeval m_scanIntervalForTimedoutQuery;
     bool m_useSSL;

--- a/include/ClientConfig.h
+++ b/include/ClientConfig.h
@@ -25,7 +25,6 @@
 #define VOLTDB_CLIENTCONFIG_H_
 #include <string>
 #include "StatusListener.h"
-#include <boost/shared_ptr.hpp>
 
 namespace voltdb {
 
@@ -43,7 +42,7 @@ public:
     ClientConfig(
             std::string username,
             std::string password,
-            boost::shared_ptr<StatusListener> listener,
+            std::shared_ptr<StatusListener> listener,
             ClientAuthHashScheme scheme = HASH_SHA1, bool enableAbandon = false,
             bool enableQueryTimeout = false, int timeoutInSec = DEFAULT_QUERY_TIMEOUT_SEC,
             bool useSSL = false);
@@ -57,7 +56,7 @@ public:
             bool useSSL = false);
     std::string m_username;
     std::string m_password;
-    boost::shared_ptr<StatusListener> m_listener;
+    std::shared_ptr<StatusListener> m_listener;
     int32_t m_maxOutstandingRequests;
     ClientAuthHashScheme m_hashScheme;
     bool m_enableAbandon;

--- a/include/ClientImpl.h
+++ b/include/ClientImpl.h
@@ -29,14 +29,13 @@
 #include <openssl/ssl.h>
 
 #include <map>
+#include <mutex>
 #include <set>
 #include <list>
 #include <string>
 #include "ProcedureCallback.hpp"
 #include "Client.h"
 #include "Procedure.hpp"
-#include <boost/atomic.hpp>
-#include <boost/thread/mutex.hpp>
 #include "ClientConfig.h"
 #include "Distributer.h"
 
@@ -245,10 +244,10 @@ private:
     std::shared_ptr<voltdb::StatusListener> m_listener;
     bool m_invocationBlockedOnBackpressure;
     bool m_backPressuredForOutstandingRequests;
-    boost::atomic<bool> m_loopBreakRequested;
+    std::atomic<bool> m_loopBreakRequested;
     bool m_isDraining;
     bool m_instanceIdIsSet;
-    boost::atomic<int32_t> m_outstandingRequests;
+    std::atomic<int32_t> m_outstandingRequests;
     //Identifier of the database instance this client is connected to
     int64_t m_clusterStartTime;
     int32_t m_leaderAddress;
@@ -265,11 +264,11 @@ private:
     bool m_enableAbandon;
 
     std::list<std::shared_ptr<PendingConnection> > m_pendingConnectionList;
-    boost::atomic<size_t> m_pendingConnectionSize;
-    boost::mutex m_pendingConnectionLock;
+    std::atomic<size_t> m_pendingConnectionSize;
+    std::mutex m_pendingConnectionLock;
 
     int m_wakeupPipe[2];
-    boost::mutex m_wakeupPipeLock;
+    std::mutex m_wakeupPipeLock;
 
     // query timeout management
 
@@ -304,8 +303,8 @@ private:
     SSL_CTX *m_clientSslCtx;
     // Reference count number of clients running to help in release of the global resource like
     // ssl ciphers, error strings and digests can be unloaded that are shared between clients
-    static boost::atomic<uint32_t> m_numberOfClients;
-    static boost::mutex m_globalResourceLock;
+    static std::atomic<uint32_t> m_numberOfClients;
+    static std::mutex m_globalResourceLock;
 
     static const int64_t VOLT_NOTIFICATION_MAGIC_NUMBER;
     static const std::string SERVICE;

--- a/include/ClientImpl.h
+++ b/include/ClientImpl.h
@@ -28,6 +28,7 @@
 #include <openssl/ossl_typ.h>
 #include <openssl/ssl.h>
 
+#include <atomic>
 #include <map>
 #include <mutex>
 #include <set>

--- a/include/ClientImpl.h
+++ b/include/ClientImpl.h
@@ -66,17 +66,17 @@ public:
      * @throws voltdb::TimerThreadException error happens when creating query timer monitor thread
      * @throws voltdb::SSLException ssl operations returns an error
      */
-    void createConnection(const std::string &hostname, const unsigned short port, const bool keepConnecting) throw (Exception, ConnectException, LibEventException, PipeCreationException, TimerThreadException, SSLException);
+    void createConnection(const std::string &hostname, const unsigned short port, const bool keepConnecting);
 
     /*
      * Synchronously invoke a stored procedure and return a the response.
      */
-    InvocationResponse invoke(Procedure &proc) throw (Exception, NoConnectionsException, UninitializedParamsException, LibEventException);
-    void invoke(Procedure &proc, boost::shared_ptr<ProcedureCallback> callback) throw (Exception, NoConnectionsException, UninitializedParamsException, LibEventException, ElasticModeMismatchException);
-    void invoke(Procedure &proc, ProcedureCallback *callback) throw (Exception, NoConnectionsException, UninitializedParamsException, LibEventException, ElasticModeMismatchException);
-    void runOnce() throw (Exception, NoConnectionsException, LibEventException);
-    void run() throw (Exception, NoConnectionsException, LibEventException);
-    void runForMaxTime(uint64_t microseconds) throw (Exception, NoConnectionsException, LibEventException);
+    InvocationResponse invoke(Procedure &proc);
+    void invoke(Procedure &proc, boost::shared_ptr<ProcedureCallback> callback);
+    void invoke(Procedure &proc, ProcedureCallback *callback);
+    void runOnce();
+    void run();
+    void runForMaxTime(uint64_t microseconds);
 
    /*
     * Enter the event loop and process pending events until all responses have been received and then return.
@@ -86,7 +86,7 @@ public:
     * @throws LibEventException An unknown error occured in libevent
     * @return true if all requests were drained and false otherwise
     */
-    bool drain() throw (Exception, NoConnectionsException, LibEventException);
+    bool drain();
     bool isDraining() const { return m_isDraining; }
     ~ClientImpl();
 
@@ -96,7 +96,7 @@ public:
     void eventBaseLoopBreak();
     void reconnectEventCallback();
 
-    void runTimeoutMonitor() throw (LibEventException);
+    void runTimeoutMonitor();
     void purgeExpiredRequests();
     void triggerScanForTimeoutRequestsEvent();
 
@@ -140,10 +140,10 @@ public:
     void logMessage(ClientLogger::CLIENT_LOG_LEVEL severity, const std::string& msg);
 
 private:
-    ClientImpl(ClientConfig config) throw (Exception, LibEventException, MDHashException, SSLException);
+    ClientImpl(ClientConfig config);
 
-    void initiateAuthentication(struct bufferevent *bev, const std::string& hostname, unsigned short port) throw (LibEventException);
-    void finalizeAuthentication(PendingConnection* pc) throw (Exception, ConnectException);
+    void initiateAuthentication(struct bufferevent *bev, const std::string& hostname, unsigned short port);
+    void finalizeAuthentication(PendingConnection* pc);
 
     /*
      * Updates procedures and topology information for transaction routing algorithm
@@ -163,7 +163,7 @@ private:
     /*
      * Initiate connection based on pending connection instance
      */
-    void initiateConnection(boost::shared_ptr<PendingConnection> &pc) throw (ConnectException, LibEventException, SSLException);
+    void initiateConnection(boost::shared_ptr<PendingConnection> &pc);
 
     /*
      * Creates a pending connection that is handled in the reconnect callback
@@ -180,13 +180,13 @@ private:
      * @param: password for which hash digest will be generated
      * @throws MDHashException: An error occurred generating hash for the password
      */
-    void hashPassword(const std::string& password) throw (MDHashException);
+    void hashPassword(const std::string& password);
 
     /**
      * Initializes SSL library, contexts and algorithms to use
      * @throws SSLException: An error occurred during initialization of SSL
      */
-    void initSslConext() throw (SSLException);
+    void initSslConext();
     inline void notifySslClose(bufferevent *bev) {
         SSL *ssl = bufferevent_openssl_get_ssl(bev);
         if (ssl == NULL) {
@@ -200,8 +200,8 @@ private:
         }
     }
 
-    void setUpTimeoutCheckerMonitor() throw (LibEventException);
-    void startMonitorThread() throw (TimerThreadException);
+    void setUpTimeoutCheckerMonitor();
+    void startMonitorThread();
     bool isReadOnly(const Procedure &proc) ;
 
 private:

--- a/include/ClientImpl.h
+++ b/include/ClientImpl.h
@@ -137,8 +137,8 @@ public:
      */
     void logMessage(ClientLogger::CLIENT_LOG_LEVEL severity, const std::string& msg);
 
-private:
     ClientImpl(ClientConfig config);
+private:
 
     void initiateAuthentication(struct bufferevent *bev, const std::string& hostname, unsigned short port);
     void finalizeAuthentication(PendingConnection* pc);

--- a/include/ClientImpl.h
+++ b/include/ClientImpl.h
@@ -36,7 +36,6 @@
 #include "Client.h"
 #include "Procedure.hpp"
 #include <boost/atomic.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 #include "ClientConfig.h"
 #include "Distributer.h"
@@ -72,7 +71,7 @@ public:
      * Synchronously invoke a stored procedure and return a the response.
      */
     InvocationResponse invoke(Procedure &proc);
-    void invoke(Procedure &proc, boost::shared_ptr<ProcedureCallback> callback);
+    void invoke(Procedure &proc, std::shared_ptr<ProcedureCallback> callback);
     void invoke(Procedure &proc, ProcedureCallback *callback);
     void runOnce();
     void run();
@@ -163,7 +162,7 @@ private:
     /*
      * Initiate connection based on pending connection instance
      */
-    void initiateConnection(boost::shared_ptr<PendingConnection> &pc);
+    void initiateConnection(std::shared_ptr<PendingConnection> &pc);
 
     /*
      * Creates a pending connection that is handled in the reconnect callback
@@ -207,15 +206,13 @@ private:
 private:
     class CallBackBookeeping {
     public:
-        CallBackBookeeping(const boost::shared_ptr<ProcedureCallback> &callback,
-                timeval timeout, bool readOnly = false) : m_procCallBack(callback),
-                                                          m_expirationTime(timeout),
-                                                          m_readOnly(readOnly) {}
+        CallBackBookeeping(const std::shared_ptr<ProcedureCallback> &callback,
+                timeval timeout, bool readOnly = false) : m_procCallBack(callback), m_expirationTime(timeout), m_readOnly(readOnly) {}
 
         CallBackBookeeping(const CallBackBookeeping& other) : m_procCallBack (other.m_procCallBack),
                 m_expirationTime (other.m_expirationTime),  m_readOnly (other.m_readOnly) {}
 
-        inline boost::shared_ptr<ProcedureCallback>  getCallback() const { return m_procCallBack; }
+        inline std::shared_ptr<ProcedureCallback>  getCallback() const { return m_procCallBack; }
         // fetch the query/proc timeout/expiration value
         inline timeval getExpirationTime() const { return m_expirationTime; }
         // returns true if the procedure is readOnly.
@@ -223,15 +220,15 @@ private:
         // helper function to set if the proc is readonly or not
         inline void setReadOnly(bool value) { m_readOnly = value; }
     private:
-        const boost::shared_ptr<ProcedureCallback> m_procCallBack;
+        const std::shared_ptr<ProcedureCallback> m_procCallBack;
         const timeval m_expirationTime;
         bool m_readOnly;
     };
 
     // Map from client data to the appropriate callback for a specific connection
-    typedef std::map< int64_t, boost::shared_ptr<CallBackBookeeping> > CallbackMap;
+    typedef std::map< int64_t, std::shared_ptr<CallBackBookeeping> > CallbackMap;
     // Map from buffer event (connection) to the connection's callback map
-    typedef std::map< struct bufferevent*, boost::shared_ptr<CallbackMap> > BEVToCallbackMap;
+    typedef std::map< struct bufferevent*, std::shared_ptr<CallbackMap>> BEVToCallbackMap;
 
     // data member variables
     Distributer  m_distributer;
@@ -241,11 +238,11 @@ private:
     int64_t m_nextRequestId;
     size_t m_nextConnectionIndex;
     std::vector<struct bufferevent*> m_bevs;
-    std::map<struct bufferevent *, boost::shared_ptr<CxnContext> > m_contexts;
+    std::map<struct bufferevent *, std::shared_ptr<CxnContext> > m_contexts;
     std::map<int, struct bufferevent *> m_hostIdToEvent;
     std::set<struct bufferevent *> m_backpressuredBevs;
     BEVToCallbackMap m_callbacks;
-    boost::shared_ptr<voltdb::StatusListener> m_listener;
+    std::shared_ptr<voltdb::StatusListener> m_listener;
     bool m_invocationBlockedOnBackpressure;
     bool m_backPressuredForOutstandingRequests;
     boost::atomic<bool> m_loopBreakRequested;
@@ -267,7 +264,7 @@ private:
     //If to use abandon in case of backpressure.
     bool m_enableAbandon;
 
-    std::list<boost::shared_ptr<PendingConnection> > m_pendingConnectionList;
+    std::list<std::shared_ptr<PendingConnection> > m_pendingConnectionList;
     boost::atomic<size_t> m_pendingConnectionSize;
     boost::mutex m_pendingConnectionLock;
 

--- a/include/ConnectionPool.h
+++ b/include/ConnectionPool.h
@@ -51,16 +51,16 @@ public:
     /*
      * Retrieve a client that connects to the specified hostname and port using the provided username and password
      */
-    voltdb::Client acquireClient(std::string hostname, std::string username, std::string password, unsigned short port = 21212, ClientAuthHashScheme sha = HASH_SHA1) throw (voltdb::ConnectException, voltdb::LibEventException, voltdb::Exception);
+    voltdb::Client acquireClient(std::string hostname, std::string username, std::string password, unsigned short port = 21212, ClientAuthHashScheme sha = HASH_SHA1);
 
     /*
      * Retrieve a client that connects to the specified hostname and port using the provided username and password
      */
-    voltdb::Client acquireClient(std::string hostname, std::string username, std::string password, StatusListener *listener, unsigned short port = 21212, ClientAuthHashScheme sha = HASH_SHA1) throw (voltdb::ConnectException, voltdb::LibEventException, voltdb::Exception);
+    voltdb::Client acquireClient(std::string hostname, std::string username, std::string password, StatusListener *listener, unsigned short port = 21212, ClientAuthHashScheme sha = HASH_SHA1);
 
-    void returnClient(Client client) throw (voltdb::Exception);
+    void returnClient(Client client);
 
-    void closeClientConnection(Client client) throw (voltdb::Exception);
+    void closeClientConnection(Client client);
 
     /*
      * Return the number of clients held by this thread

--- a/include/ConnectionPool.h
+++ b/include/ConnectionPool.h
@@ -33,8 +33,8 @@ namespace voltdb {
 
 class ConnectionPool;
 class ClientStuff;
-typedef std::vector<boost::shared_ptr<ClientStuff> > ClientSet;
-typedef std::map<std::string, std::vector<boost::shared_ptr<ClientStuff> > > ClientMap;
+typedef std::vector<std::shared_ptr<ClientStuff>> ClientSet;
+typedef std::map<std::string, std::vector<std::shared_ptr<ClientStuff>>> ClientMap;
 
 void cleanupOnScriptEnd(ClientSet *clients);
 

--- a/include/Distributer.h
+++ b/include/Distributer.h
@@ -77,7 +77,7 @@ public:
          m_PartitionToHostId.clear();
      }
 
-     ProcedureInfo* getProcedure(const std::string& procName) throw (UnknownProcedureException);
+     ProcedureInfo* getProcedure(const std::string& procName);
      int getHashedPartitionForParameter(ByteBuffer &paramBuffer, int parameterId);
      int getHostIdByPartitionId(int partitionId);
      void handleTopologyNotification(const std::vector<voltdb::Table>& t);

--- a/include/Distributer.h
+++ b/include/Distributer.h
@@ -24,17 +24,13 @@
 #ifndef DISTRIBUTER_H_
 #define DISTRIBUTER_H_
 
-#include <boost/scoped_ptr.hpp>
-#include <boost/thread/locks.hpp>
-#include <boost/thread/shared_mutex.hpp>
 #include "TheHashinator.h"
 #include "Table.h"
 #include "ByteBuffer.hpp"
 #include "Exception.hpp"
 #include <map>
+#include <mutex>
 #include <string>
-
-
 
 namespace voltdb {
 
@@ -90,9 +86,9 @@ private:
      std::map<int, int> m_PartitionToHostId;
      bool m_isUpdating;
      bool m_isElastic;
-     boost::scoped_ptr<TheHashinator> m_hashinator;
+     std::unique_ptr<TheHashinator> m_hashinator;
 
-     static boost::shared_mutex m_procInfoLock;
+     static std::mutex m_procInfoLock;
 
      voltdb::Table m_savedTopoTable;
 };

--- a/include/ElasticHashinator.h
+++ b/include/ElasticHashinator.h
@@ -97,7 +97,7 @@ public:
     }
 
 private:
-    boost::scoped_array<int32_t> m_tokens;
+    std::unique_ptr<int32_t[]> m_tokens;
     uint32_t m_tokenCount;
 
     int32_t partitionForToken(int32_t hash) const {

--- a/include/GeographyPoint.hpp
+++ b/include/GeographyPoint.hpp
@@ -97,7 +97,7 @@ public:
     bool isNull() const {
         return m_longitude == NULL_COORDINATE && m_latitude == NULL_COORDINATE;
     }
-    
+
     /**
      * Test that this is equal to the other.  We take care to compare points
      * on the poles properly, when the latitude is not defined, and to compare
@@ -131,7 +131,7 @@ public:
      * See the VoltDB wire protocol specification for details.
      */
     static GeographyPoint fromXYZ(double x, double y, double z);
-    
+
     /**
      * Return true iff two points are approximately equal.
      * This is true if their latitudes and longitudes are
@@ -146,7 +146,7 @@ public:
      */
     bool approximatelyEqual(const GeographyPoint &aOther,
                             double epsilon) const;
-    
+
     /**
      * Convert from longitude/latitude to points on the unit
      * sphere.  See the VoltDB wire protocol specification for
@@ -160,7 +160,7 @@ public:
     int32_t deserializeFrom(ByteBuffer &message,
                             int32_t     offset,
                             bool       &wasNull);
-    static const double NULL_COORDINATE = 360.0;
+    static const double NULL_COORDINATE;
 private:
     double m_longitude;
     double m_latitude;

--- a/include/InvocationResponse.hpp
+++ b/include/InvocationResponse.hpp
@@ -284,7 +284,6 @@ private:
         } return str;
     }
 
-private:
     int64_t m_clientData;
     int8_t m_statusCode;
     std::string m_statusString;

--- a/include/InvocationResponse.hpp
+++ b/include/InvocationResponse.hpp
@@ -23,10 +23,8 @@
 
 #ifndef VOLTDB_INVOCATIONRESPONSE_HPP_
 #define VOLTDB_INVOCATIONRESPONSE_HPP_
-#include <boost/shared_array.hpp>
 #include <vector>
 #include <sstream>
-#include <boost/shared_ptr.hpp>
 #include "ByteBuffer.hpp"
 #include "Table.h"
 #include <iostream>
@@ -97,13 +95,13 @@ public:
     }
 
 #ifdef SWIG
-    %ignore InvocationResponse(boost::shared_array<char> data, int32_t length);
+    %ignore InvocationResponse(std::shared_ptr<char[]> data, int32_t length);
 #endif
     /*
      * Constructor for taking shared ownership of a message buffer
      * containing a response to a stored procedure invocation
      */
-    InvocationResponse(boost::shared_array<char>& data, int32_t length) : m_results(0) {
+    InvocationResponse(std::shared_ptr<char[]>& data, int32_t length) : m_results(0) {
         SharedByteBuffer buffer(data, length);
         int8_t version = buffer.getInt8();
         assert(version == 0);

--- a/include/ParameterSet.hpp
+++ b/include/ParameterSet.hpp
@@ -26,7 +26,6 @@
 #include "Parameter.hpp"
 #include <vector>
 #include "Table.h"
-#include "boost/shared_ptr.hpp"
 #include "Decimal.hpp"
 #include "GeographyPoint.hpp"
 #include "Geography.hpp"

--- a/include/ParameterSet.hpp
+++ b/include/ParameterSet.hpp
@@ -68,8 +68,7 @@ public:
      * @return Reference to this parameter set to allow invocation chaining.
      */
     template <WireType T>
-    ParameterSet& addTypedBytes(const int32_t size, const uint8_t *value)
-    throw (voltdb::ParamMismatchException) {
+    ParameterSet& addTypedBytes(const int32_t size, const uint8_t *value) {
         assert(WIRE_TYPE_VARBINARY == T || WIRE_TYPE_STRING == T);
         validateType(T, false);
         if (value) {
@@ -87,8 +86,7 @@ public:
     * @return Reference to this parameter set to allow invocation chaining.
     */
     template <WireType T, typename ItemType>
-    ParameterSet& addTypedByteArray(const typename std::vector<ItemType> &vals)
-        throw (voltdb::ParamMismatchException) {
+    ParameterSet& addTypedByteArray(const typename std::vector<ItemType> &vals) {
        assert(WIRE_TYPE_VARBINARY==T || WIRE_TYPE_STRING == T);
        validateType(T, true);
        int32_t totalByteSize = 0;
@@ -113,8 +111,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addBytes(const int32_t size, const uint8_t *value)
-    throw (voltdb::ParamMismatchException) {
+    ParameterSet& addBytes(const int32_t size, const uint8_t *value) {
         return addTypedBytes<WIRE_TYPE_VARBINARY>(size, value);
     }
 
@@ -122,8 +119,7 @@ public:
     * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
     * @return Reference to this parameter set to allow invocation chaining.
     */
-   ParameterSet& addBytes(const std::vector<buffer_t> &vals)
-   throw (voltdb::ParamMismatchException) {
+   ParameterSet& addBytes(const std::vector<buffer_t> &vals) {
        return addTypedByteArray<WIRE_TYPE_VARBINARY, buffer_t>(vals);
    }
 
@@ -132,7 +128,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addDecimal(Decimal val) throw (voltdb::ParamMismatchException) {
+    ParameterSet& addDecimal(Decimal val) {
         validateType(WIRE_TYPE_DECIMAL, false);
         m_buffer.ensureRemaining(static_cast<int32_t>(sizeof(Decimal)) + 1);
         m_buffer.putInt8(WIRE_TYPE_DECIMAL);
@@ -146,7 +142,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addDecimal(const std::vector<Decimal>& vals) throw (voltdb::ParamMismatchException) {
+    ParameterSet& addDecimal(const std::vector<Decimal>& vals) {
         validateType(WIRE_TYPE_DECIMAL, true);
         m_buffer.ensureRemaining(4 + static_cast<int32_t>(sizeof(Decimal) * vals.size()));
         m_buffer.putInt8(WIRE_TYPE_ARRAY);
@@ -164,7 +160,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addTimestamp(int64_t val) throw (voltdb::ParamMismatchException) {
+    ParameterSet& addTimestamp(int64_t val) {
         validateType(WIRE_TYPE_TIMESTAMP, false);
         m_buffer.ensureRemaining(9);
         m_buffer.putInt8(WIRE_TYPE_TIMESTAMP);
@@ -178,7 +174,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addTimestamp(const std::vector<int64_t>& vals) throw (voltdb::ParamMismatchException) {
+    ParameterSet& addTimestamp(const std::vector<int64_t>& vals) {
         validateType(WIRE_TYPE_TIMESTAMP, true);
         m_buffer.ensureRemaining(4 + static_cast<int32_t>(sizeof(int64_t) * vals.size()));
         m_buffer.putInt8(WIRE_TYPE_ARRAY);
@@ -196,7 +192,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addInt64(int64_t val) throw (voltdb::ParamMismatchException) {
+    ParameterSet& addInt64(int64_t val) {
         validateType(WIRE_TYPE_BIGINT, false);
         m_buffer.ensureRemaining(9);
         m_buffer.putInt8(WIRE_TYPE_BIGINT);
@@ -210,7 +206,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addInt64(const std::vector<int64_t>& vals) throw (voltdb::ParamMismatchException) {
+    ParameterSet& addInt64(const std::vector<int64_t>& vals) {
         validateType(WIRE_TYPE_BIGINT, true);
         m_buffer.ensureRemaining(4 + static_cast<int32_t>(sizeof(int64_t) * vals.size()));
         m_buffer.putInt8(WIRE_TYPE_ARRAY);
@@ -228,7 +224,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addInt32(int32_t val) throw (voltdb::ParamMismatchException) {
+    ParameterSet& addInt32(int32_t val) {
         validateType(WIRE_TYPE_INTEGER, false);
         m_buffer.ensureRemaining(5);
         m_buffer.putInt8(WIRE_TYPE_INTEGER);
@@ -242,7 +238,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addInt32(const std::vector<int32_t>& vals) throw (voltdb::ParamMismatchException) {
+    ParameterSet& addInt32(const std::vector<int32_t>& vals) {
         validateType(WIRE_TYPE_INTEGER, true);
         m_buffer.ensureRemaining(4 + static_cast<int32_t>(sizeof(int32_t) * vals.size()));
         m_buffer.putInt8(WIRE_TYPE_ARRAY);
@@ -260,7 +256,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addInt16(int16_t val) throw (voltdb::ParamMismatchException) {
+    ParameterSet& addInt16(int16_t val) {
         validateType(WIRE_TYPE_SMALLINT, false);
         m_buffer.ensureRemaining(3);
         m_buffer.putInt8(WIRE_TYPE_SMALLINT);
@@ -274,7 +270,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addInt16(const std::vector<int16_t>& vals) throw (voltdb::ParamMismatchException) {
+    ParameterSet& addInt16(const std::vector<int16_t>& vals) {
         validateType(WIRE_TYPE_SMALLINT, true);
         m_buffer.ensureRemaining(4 + static_cast<int32_t>(sizeof(int16_t) * vals.size()));
         m_buffer.putInt8(WIRE_TYPE_ARRAY);
@@ -292,7 +288,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addInt8(int8_t val) throw (voltdb::ParamMismatchException) {
+    ParameterSet& addInt8(int8_t val) {
         validateType(WIRE_TYPE_TINYINT, false);
         m_buffer.ensureRemaining(2);
         m_buffer.putInt8(WIRE_TYPE_TINYINT);
@@ -306,7 +302,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addInt8(const std::vector<int8_t>& vals) throw (voltdb::ParamMismatchException) {
+    ParameterSet& addInt8(const std::vector<int8_t>& vals) {
         validateType(WIRE_TYPE_TINYINT, true);
         m_buffer.ensureRemaining(6 + static_cast<int32_t>(sizeof(int8_t) * vals.size()));
         // Convert array of TINYINT to VARBINARY.
@@ -324,7 +320,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addDouble(double val) throw (voltdb::ParamMismatchException) {
+    ParameterSet& addDouble(double val) {
         validateType(WIRE_TYPE_FLOAT, false);
         m_buffer.ensureRemaining(9);
         m_buffer.putInt8(WIRE_TYPE_FLOAT);
@@ -338,7 +334,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addDouble(const std::vector<double>& vals) throw (voltdb::ParamMismatchException) {
+    ParameterSet& addDouble(const std::vector<double>& vals) {
         validateType(WIRE_TYPE_FLOAT, true);
         m_buffer.ensureRemaining(2 + static_cast<int32_t>(sizeof(double) * vals.size()));
         m_buffer.putInt8(WIRE_TYPE_ARRAY);
@@ -359,7 +355,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addNull() throw (voltdb::ParamMismatchException) {
+    ParameterSet& addNull() {
         if (m_currentParam > m_parameters.size()) {
             throw new ParamMismatchException();
         }
@@ -374,8 +370,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addString(const int32_t size, const char* data)
-    throw (voltdb::ParamMismatchException) {
+    ParameterSet& addString(const int32_t size, const char* data) {
         return addTypedBytes<WIRE_TYPE_STRING>(size, (const uint8_t*)data);
     }
 
@@ -384,8 +379,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addString(const std::string& val)
-    throw (voltdb::ParamMismatchException) {
+    ParameterSet& addString(const std::string& val) {
         return addString(val.size(), val.data());
     }
 
@@ -394,8 +388,7 @@ public:
      * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
      * @return Reference to this parameter set to allow invocation chaining.
      */
-    ParameterSet& addString(const std::vector<std::string>& vals)
-    throw (voltdb::ParamMismatchException) {
+    ParameterSet& addString(const std::vector<std::string>& vals) {
         return addTypedByteArray<WIRE_TYPE_STRING, std::string>(vals);
         }
 
@@ -404,8 +397,7 @@ public:
     * @throws ParamMismatchException Supplied parameter is the wrong type for this position or too many have been set
     * @return Reference to this parameter set to allow invocation chaining.
     */
-    ParameterSet& addString(const std::vector<buffer_t> &vals)
-    throw (voltdb::ParamMismatchException) {
+    ParameterSet& addString(const std::vector<buffer_t> &vals) {
         return addTypedByteArray<WIRE_TYPE_STRING, buffer_t>(vals);
     }
 

--- a/include/ProcedureCallback.hpp
+++ b/include/ProcedureCallback.hpp
@@ -45,7 +45,7 @@ public:
      * and passes any caught exceptions to the status listener.
      * @return true if the event loop should break after invoking this callback, false otherwise
      */
-    virtual bool callback(InvocationResponse response) throw (voltdb::Exception) = 0;
+    virtual bool callback(InvocationResponse response) = 0;
     virtual void abandon(AbandonReason reason) {}
     // Mechanism for procedure to over-ride abandon property set in client in event of backpressure.
     // @return true: allow abandoning of requests in case of back pressure

--- a/include/ProcedureCallback.hpp
+++ b/include/ProcedureCallback.hpp
@@ -24,7 +24,6 @@
 #ifndef VOLTDB_PROCEDURECALLBACK_HPP_
 #define VOLTDB_PROCEDURECALLBACK_HPP_
 #include "InvocationResponse.hpp"
-#include <boost/shared_ptr.hpp>
 namespace voltdb {
 
 /*

--- a/include/Row.hpp
+++ b/include/Row.hpp
@@ -62,7 +62,7 @@ public:
      * not match the type of the get method.
      * @return Whether the buffer provided was large enough.
      */
-    bool getVarbinary(int32_t column, int32_t bufsize, uint8_t *out_value, int32_t *out_len) throw(voltdb::InvalidColumnException) {
+    bool getVarbinary(int32_t column, int32_t bufsize, uint8_t *out_value, int32_t *out_len) {
         validateType(WIRE_TYPE_VARBINARY, column);
         return m_data.getBytes(getOffset(column), m_wasNull, bufsize, out_value, out_len);
     }
@@ -74,7 +74,7 @@ public:
      * not match the type of the get method.
      * @return Decimal value at the specified column
      */
-    Decimal getDecimal(int32_t column) throw(voltdb::InvalidColumnException) {
+    Decimal getDecimal(int32_t column) {
         validateType(WIRE_TYPE_DECIMAL, column);
         char data[16];
         m_data.get(getOffset(column), data, 16);
@@ -90,7 +90,7 @@ public:
      * not match the type of the get method.
      * @return Timestamp value at the specified column
      */
-    int64_t getTimestamp(int32_t column) throw(voltdb::InvalidColumnException) {
+    int64_t getTimestamp(int32_t column) {
         validateType(WIRE_TYPE_TIMESTAMP, column);
         int64_t retval = m_data.getInt64(getOffset(column));
         if (retval == INT64_MIN) m_wasNull = true;
@@ -104,7 +104,7 @@ public:
      * not match the type of the get method.
      * @return int64 value at the specified column
      */
-    int64_t getInt64(int32_t column) throw(voltdb::InvalidColumnException) {
+    int64_t getInt64(int32_t column) {
         WireType type = validateType(WIRE_TYPE_BIGINT, column);
         int64_t retval;
         switch (type) {
@@ -137,7 +137,7 @@ public:
      * not match the type of the get method.
      * @return int32 value at the specified column
      */
-    int32_t getInt32(int32_t column) throw(voltdb::InvalidColumnException) {
+    int32_t getInt32(int32_t column) {
         WireType type = validateType(WIRE_TYPE_INTEGER, column);
         int32_t retval;
         switch (type) {
@@ -166,7 +166,7 @@ public:
      * not match the type of the get method.
      * @return int16 value at the specified column
      */
-    int16_t getInt16(int32_t column) throw(voltdb::InvalidColumnException) {
+    int16_t getInt16(int32_t column) {
         WireType type = validateType(WIRE_TYPE_SMALLINT, column);
         int16_t retval;
         switch (type) {
@@ -191,7 +191,7 @@ public:
      * not match the type of the get method.
      * @return int8 value at the specified column
      */
-    int8_t getInt8(int32_t column) throw(voltdb::InvalidColumnException) {
+    int8_t getInt8(int32_t column) {
         validateType(WIRE_TYPE_TINYINT, column);
         int8_t retval = m_data.getInt8(getOffset(column));
         if (retval == INT8_MIN) {
@@ -207,7 +207,7 @@ public:
      * not match the type of the get method.
      * @return double value at the specified column
      */
-    double getDouble(int32_t column) throw(voltdb::InvalidColumnException) {
+    double getDouble(int32_t column) {
         validateType(WIRE_TYPE_FLOAT, column);
         double retval = m_data.getDouble(getOffset(column));
         if (retval <= -1.7E+308) {
@@ -223,7 +223,7 @@ public:
      * not match the type of the get method.
      * @return String value at the specified column
      */
-    std::string getString(int32_t column) throw(voltdb::InvalidColumnException) {
+    std::string getString(int32_t column) {
         validateType(WIRE_TYPE_STRING, column);
         return m_data.getString(getOffset(column), m_wasNull);
     }
@@ -235,7 +235,7 @@ public:
      * not match the type of the get method.
      * @return the deserialized GeographyPoint value.
      */
-    GeographyPoint getGeographyPoint(int32_t column) throw(voltdb::InvalidColumnException) {
+    GeographyPoint getGeographyPoint(int32_t column) {
         validateType(WIRE_TYPE_GEOGRAPHY_POINT, column);
         GeographyPoint gpoint(m_data, getOffset(column), m_wasNull);
         return gpoint;
@@ -248,7 +248,7 @@ public:
      * not match the type of the get method.
      * @return the deserialized geography value.
      */
-    Geography getGeography(int32_t column) throw(voltdb::InvalidColumnException) {
+    Geography getGeography(int32_t column) {
         validateType(WIRE_TYPE_GEOGRAPHY, column);
         m_wasNull = false;
         return Geography(m_data, getOffset(column), m_wasNull);
@@ -259,7 +259,7 @@ public:
      * @throws InvalidColumnException The name of the column was invalid.
      * @return true if the value is NULL and false otherwise
      */
-    bool isNull(int32_t column) throw(voltdb::InvalidColumnException, voltdb::UnsupportedTypeException) {
+    bool isNull(int32_t column) {
         if (column < 0 || column >= static_cast<ssize_t>(m_columns->size())) {
             throw InvalidColumnException(column, m_columns->size());
         }
@@ -301,8 +301,7 @@ public:
      * not match the type of the get method.
      * @return Whether the buffer provided was large enough.
      */
-    bool getVarbinary(const std::string& cname, int32_t bufsize, uint8_t *out_value, int32_t *out_len)
-    throw(voltdb::InvalidColumnException) {
+    bool getVarbinary(const std::string& cname, int32_t bufsize, uint8_t *out_value, int32_t *out_len) {
         return getVarbinary(getColumnIndexByName(cname), bufsize, out_value, out_len);
     }
 
@@ -313,7 +312,7 @@ public:
      * does not match the column type.
      * @return Decimal value at the specified column
      */
-    Decimal getDecimal(const std::string& cname) throw(voltdb::InvalidColumnException) {
+    Decimal getDecimal(const std::string& cname) {
         return getDecimal(getColumnIndexByName(cname));
     }
 
@@ -324,7 +323,7 @@ public:
      * does not match the column type.
      * @return Timestamp value at the specified column
      */
-    int64_t getTimestamp(const std::string& cname) throw(voltdb::InvalidColumnException) {
+    int64_t getTimestamp(const std::string& cname) {
         return getTimestamp(getColumnIndexByName(cname));
     }
 
@@ -335,7 +334,7 @@ public:
      * does not match the column type.
      * @return int64 value at the specified column
      */
-    int64_t getInt64(const std::string& cname) throw(voltdb::InvalidColumnException) {
+    int64_t getInt64(const std::string& cname) {
         return getInt64(getColumnIndexByName(cname));
     }
 
@@ -346,7 +345,7 @@ public:
      * does not match the column type.
      * @return int32 value at the specified column
      */
-    int32_t getInt32(const std::string& cname) throw(voltdb::InvalidColumnException) {
+    int32_t getInt32(const std::string& cname) {
         return getInt32(getColumnIndexByName(cname));
     }
 
@@ -357,7 +356,7 @@ public:
      * does not match the column type.
      * @return int16 value at the specified column
      */
-    int16_t getInt16(const std::string& cname) throw(voltdb::InvalidColumnException) {
+    int16_t getInt16(const std::string& cname) {
         return getInt16(getColumnIndexByName(cname));
     }
 
@@ -368,7 +367,7 @@ public:
      * does not match the column type.
      * @return int8 value at the specified column
      */
-    int8_t getInt8(const std::string& cname) throw(voltdb::InvalidColumnException) {
+    int8_t getInt8(const std::string& cname) {
         return getInt8(getColumnIndexByName(cname));
     }
 
@@ -379,7 +378,7 @@ public:
      * does not match the column type.
      * @return double value at the specified column
      */
-    double getDouble(const std::string& cname) throw(voltdb::InvalidColumnException) {
+    double getDouble(const std::string& cname) {
         return getDouble(getColumnIndexByName(cname));
     }
 
@@ -390,7 +389,7 @@ public:
      * does not match the column type.
      * @return string value at the specified column
      */
-    std::string getString(const std::string& cname) throw(voltdb::InvalidColumnException) {
+    std::string getString(const std::string& cname) {
         return getString(getColumnIndexByName(cname));
     }
 
@@ -401,7 +400,7 @@ public:
      * @throws UnsupportedTypeException always
      * @return never returns
      */
-    GeographyPoint getGeographyPoint(const std::string& cname) throw(UnsupportedTypeException) {
+    GeographyPoint getGeographyPoint(const std::string& cname) {
         return getGeographyPoint(getColumnIndexByName(cname));
     }
 
@@ -412,7 +411,7 @@ public:
      * @throws UnsupportedTypeException always
      * @return never returns
      */
-    Geography getGeography(const std::string& cname) throw(UnsupportedTypeException) {
+    Geography getGeography(const std::string& cname) {
         return getGeography(getColumnIndexByName(cname));
     }
 
@@ -421,7 +420,7 @@ public:
      * @throws InvalidColumnException The name of the column was invalid.
      * @return true if the value is NULL and false otherwise
      */
-    bool isNull(const std::string& cname) throw(voltdb::InvalidColumnException) {
+    bool isNull(const std::string& cname) {
         int32_t column = getColumnIndexByName(cname);
         return isNull(column);
     }
@@ -496,7 +495,7 @@ public:
         return *m_columns;
     }
 private:
-    WireType validateType(WireType type, int32_t index)  throw (InvalidColumnException) {
+    WireType validateType(WireType type, int32_t index) {
         if (index < 0 ||
                 index >= static_cast<ssize_t>(m_columns->size())) {
             throw InvalidColumnException(index, m_columns->size());

--- a/include/Row.hpp
+++ b/include/Row.hpp
@@ -55,6 +55,34 @@ public:
         m_data(rowData), m_columns(columns), m_wasNull(false), m_offsets(columns->size()), m_hasCalculatedOffsets(false) {
     }
 
+    std::string get(int32_t column) {
+       switch(m_columns->at(column).type()) {
+          case WIRE_TYPE_TINYINT:
+             return std::to_string(getInt8(column));
+          case WIRE_TYPE_SMALLINT:
+             return std::to_string(getInt16(column));
+          case WIRE_TYPE_INTEGER:
+             return std::to_string(getInt32(column));
+          case WIRE_TYPE_BIGINT:
+             return std::to_string(getInt64(column));
+          case WIRE_TYPE_FLOAT:
+             return std::to_string(getDouble(column));
+          case WIRE_TYPE_STRING:
+             return getString(column);
+          case WIRE_TYPE_TIMESTAMP:
+             return std::to_string(getTimestamp(column));
+          case WIRE_TYPE_DECIMAL:
+             return getDecimal(column).toString();
+          case WIRE_TYPE_VARBINARY:
+             return "VARBINARY VALUE";
+          case WIRE_TYPE_GEOGRAPHY_POINT:
+             return getGeographyPoint(column).toString();
+          case WIRE_TYPE_GEOGRAPHY:
+             return getGeography(column).toString();
+          default:
+             assert(false);
+       }
+    }
     /*
      * Retrieve the value at the specified column index as bytes. The type of the column
      * must be Varbinary.

--- a/include/Row.hpp
+++ b/include/Row.hpp
@@ -56,31 +56,35 @@ public:
     }
 
     std::string get(int32_t column) {
-       switch(m_columns->at(column).type()) {
-          case WIRE_TYPE_TINYINT:
-             return std::to_string(getInt8(column));
-          case WIRE_TYPE_SMALLINT:
-             return std::to_string(getInt16(column));
-          case WIRE_TYPE_INTEGER:
-             return std::to_string(getInt32(column));
-          case WIRE_TYPE_BIGINT:
-             return std::to_string(getInt64(column));
-          case WIRE_TYPE_FLOAT:
-             return std::to_string(getDouble(column));
-          case WIRE_TYPE_STRING:
-             return getString(column);
-          case WIRE_TYPE_TIMESTAMP:
-             return std::to_string(getTimestamp(column));
-          case WIRE_TYPE_DECIMAL:
-             return getDecimal(column).toString();
-          case WIRE_TYPE_VARBINARY:
-             return "VARBINARY VALUE";
-          case WIRE_TYPE_GEOGRAPHY_POINT:
-             return getGeographyPoint(column).toString();
-          case WIRE_TYPE_GEOGRAPHY:
-             return getGeography(column).toString();
-          default:
-             assert(false);
+       if (isNull(column)) {
+          return "NULL";
+       } else {
+          switch(m_columns->at(column).type()) {
+             case WIRE_TYPE_TINYINT:
+                return std::to_string(getInt8(column));
+             case WIRE_TYPE_SMALLINT:
+                return std::to_string(getInt16(column));
+             case WIRE_TYPE_INTEGER:
+                return std::to_string(getInt32(column));
+             case WIRE_TYPE_BIGINT:
+                return std::to_string(getInt64(column));
+             case WIRE_TYPE_FLOAT:
+                return std::to_string(getDouble(column));
+             case WIRE_TYPE_STRING:
+                return getString(column);
+             case WIRE_TYPE_TIMESTAMP:
+                return std::to_string(getTimestamp(column));
+             case WIRE_TYPE_DECIMAL:
+                return getDecimal(column).toString();
+             case WIRE_TYPE_VARBINARY:
+                return "VARBINARY VALUE";
+             case WIRE_TYPE_GEOGRAPHY_POINT:
+                return getGeographyPoint(column).toString();
+             case WIRE_TYPE_GEOGRAPHY:
+                return getGeography(column).toString();
+             default:
+                assert(false);
+          }
        }
     }
     /*

--- a/include/Row.hpp
+++ b/include/Row.hpp
@@ -49,9 +49,9 @@ public:
      * Construct a row from a buffer containing the row data.
      */
 #ifdef SWIG
-    %ignore Row(SharedByteBuffer rowData, boost::shared_ptr<std::vector<voltdb::Column> > columns);
+    %ignore Row(SharedByteBuffer rowData, std::shared_ptr<std::vector<voltdb::Column>> columns);
 #endif
-    Row(SharedByteBuffer& rowData, boost::shared_ptr<std::vector<voltdb::Column> >& columns) :
+    Row(SharedByteBuffer& rowData, std::shared_ptr<std::vector<voltdb::Column>>& columns) :
         m_data(rowData), m_columns(columns), m_wasNull(false), m_offsets(columns->size()), m_hasCalculatedOffsets(false) {
     }
 
@@ -622,7 +622,7 @@ private:
     }
 
     SharedByteBuffer m_data;
-    boost::shared_ptr<std::vector<voltdb::Column> > m_columns;
+    std::shared_ptr<std::vector<voltdb::Column> > m_columns;
     bool m_wasNull;
     std::vector<int32_t> m_offsets;
     bool m_hasCalculatedOffsets;

--- a/include/RowBuilder.h
+++ b/include/RowBuilder.h
@@ -46,7 +46,7 @@ class TableTest;
 class RowBuilder {
 friend class TableTest;
 private:
-    void validateType(WireType type) throw (InvalidColumnException, RowCreationException) {
+    void validateType(WireType type) {
         if (m_currentColumnIndex >= m_columns.size()) {
             throw InvalidColumnException(m_currentColumnIndex, m_columns.size());
         }
@@ -65,10 +65,10 @@ private:
 
 public:
     // Initializes the Rowbuilder with schema of the table for which the row will be constructed
-    RowBuilder(const std::vector<Column> &schema) throw (RowCreationException);
+    RowBuilder(const std::vector<Column> &schema);
 
 
-    RowBuilder& addInt64(int64_t val) throw (InvalidColumnException, RowCreationException) {
+    RowBuilder& addInt64(int64_t val) {
         validateType(WIRE_TYPE_BIGINT);
         m_buffer.ensureRemaining(8);
         m_buffer.putInt64(val);
@@ -76,7 +76,7 @@ public:
         return *this;
     }
 
-    RowBuilder& addInt32(int32_t val) throw (InvalidColumnException, RowCreationException) {
+    RowBuilder& addInt32(int32_t val) {
         validateType(WIRE_TYPE_INTEGER);
         m_buffer.ensureRemaining(4);
         m_buffer.putInt32(val);
@@ -84,7 +84,7 @@ public:
         return *this;
     }
 
-    RowBuilder& addInt16(int16_t val) throw (InvalidColumnException, RowCreationException) {
+    RowBuilder& addInt16(int16_t val) {
         validateType(WIRE_TYPE_SMALLINT);
         m_buffer.ensureRemaining(2);
         m_buffer.putInt16(val);
@@ -92,7 +92,7 @@ public:
         return *this;
     }
 
-    RowBuilder& addInt8(int8_t val) throw (InvalidColumnException, RowCreationException) {
+    RowBuilder& addInt8(int8_t val) {
         validateType(WIRE_TYPE_TINYINT);
         m_buffer.ensureRemaining(1);
         m_buffer.putInt8(val);
@@ -100,7 +100,7 @@ public:
         return *this;
     }
 
-    RowBuilder& addDouble(double val) throw (InvalidColumnException, RowCreationException) {
+    RowBuilder& addDouble(double val) {
         validateType(WIRE_TYPE_FLOAT);
         m_buffer.ensureRemaining(8);
         m_buffer.putDouble(val);
@@ -108,7 +108,7 @@ public:
         return *this;
     }
 
-    RowBuilder& addNull() throw (InvalidColumnException) {
+    RowBuilder& addNull() {
         if (m_currentColumnIndex >= m_columns.size()) {
             throw InvalidColumnException(m_currentColumnIndex, m_columns.size());
         }
@@ -169,7 +169,7 @@ public:
         return *this;
     }
 
-    RowBuilder& addString(const std::string& val) throw (InvalidColumnException, RowCreationException) {
+    RowBuilder& addString(const std::string& val) {
         validateType(WIRE_TYPE_STRING);
         m_buffer.ensureRemaining(4 + static_cast<int32_t>(val.size()));
         m_buffer.putString(val);
@@ -177,7 +177,7 @@ public:
         return *this;
     }
 
-    RowBuilder& addVarbinary(const int32_t bufsize, const uint8_t *in_value) throw (InvalidColumnException, RowCreationException) {
+    RowBuilder& addVarbinary(const int32_t bufsize, const uint8_t *in_value) {
         validateType(WIRE_TYPE_VARBINARY);
         m_buffer.ensureRemaining(4 + bufsize);
         m_buffer.putBytes(bufsize, in_value);
@@ -185,7 +185,7 @@ public:
         return *this;
     }
 
-    RowBuilder& addTimeStamp(int64_t value) throw (InvalidColumnException, RowCreationException) {
+    RowBuilder& addTimeStamp(int64_t value) {
         validateType(WIRE_TYPE_TIMESTAMP);
         m_buffer.ensureRemaining(8);
         m_buffer.putInt64(value);
@@ -201,7 +201,7 @@ public:
         return *this;
     }
 
-    RowBuilder& addGeographyPoint(const GeographyPoint &val) throw (InvalidColumnException, RowCreationException)  {
+    RowBuilder& addGeographyPoint(const GeographyPoint &val) {
         validateType(WIRE_TYPE_GEOGRAPHY_POINT);
         // 2*sizeof(double) bytes for the payload.
         m_buffer.ensureRemaining(2*sizeof(double));
@@ -211,7 +211,7 @@ public:
         return *this;
     }
 
-    RowBuilder& addGeography(const Geography &val) throw (InvalidColumnException, RowCreationException) {
+    RowBuilder& addGeography(const Geography &val) {
         validateType(WIRE_TYPE_GEOGRAPHY);
         int32_t valSize = val.getSerializedSize();
         m_buffer.ensureRemaining(1 + valSize);
@@ -230,7 +230,7 @@ public:
      * Precondition:  All the columns of the row schema should be
      * populated/initialized
      */
-    int32_t serializeTo(ByteBuffer &buffer) throw (UninitializedColumnException) {
+    int32_t serializeTo(ByteBuffer &buffer) {
         if (m_currentColumnIndex != m_columns.size()) {
             throw UninitializedColumnException(m_columns.size(), m_currentColumnIndex);
         }

--- a/include/RowBuilder.h
+++ b/include/RowBuilder.h
@@ -27,7 +27,6 @@
 #include "WireType.h"
 #include "Table.h"
 #include "Column.hpp"
-#include "boost/shared_ptr.hpp"
 #include <stdint.h>
 #include "Exception.hpp"
 #include "Decimal.hpp"

--- a/include/StatusListener.h
+++ b/include/StatusListener.h
@@ -44,7 +44,7 @@ public:
      */
     virtual bool uncaughtException(
             std::exception exception,
-            boost::shared_ptr<voltdb::ProcedureCallback> callback,
+            std::shared_ptr<voltdb::ProcedureCallback> callback,
             voltdb::InvocationResponse response) = 0;
 
     /*

--- a/include/Table.h
+++ b/include/Table.h
@@ -25,7 +25,6 @@
 #define VOLTDB_TABLE_H_
 
 #include "ByteBuffer.hpp"
-#include <boost/shared_ptr.hpp>
 #include <vector>
 #include "Column.hpp"
 #include <sstream>
@@ -120,7 +119,7 @@ public:
     const static int8_t DEFAULT_STATUS_CODE;
 private:
     void validateRowScehma(const std::vector<Column>& schema) const;
-    boost::shared_ptr<std::vector<voltdb::Column> > m_columns;
+    std::shared_ptr<std::vector<voltdb::Column>> m_columns;
     int32_t m_rowCountPosition;
     int32_t m_rowCount;
     mutable voltdb::SharedByteBuffer m_buffer;

--- a/include/Table.h
+++ b/include/Table.h
@@ -46,7 +46,7 @@ public:
      * to the shared buffer indefinitely so watch out for unwanted memory retension.
      */
     Table(SharedByteBuffer buffer);
-    Table(const std::vector<Column> &columns) throw (TableException);
+    Table(const std::vector<Column> &columns);
     Table() {}
 
     ~Table() {
@@ -73,7 +73,7 @@ public:
      * Precondition: Row and Table schema should be same
      * and all the row columns should be init'ed
      */
-    void addRow(RowBuilder& row) throw (TableException, UninitializedColumnException, InCompatibleSchemaException);
+    void addRow(RowBuilder& row);
 
     /*
      * Retrieve a copy of the column metadata.
@@ -95,7 +95,7 @@ public:
      * have ample space available to serialize table data. The needed space can
      * be queried using getSerializedSize()
      */
-    int32_t serializeTo(ByteBuffer& buffer) throw (TableException);
+    int32_t serializeTo(ByteBuffer& buffer);
 
     /**
      * Returns the size in bytes needed to serialize the current table data
@@ -119,7 +119,7 @@ public:
     const static int32_t MAX_TUPLE_LENGTH;
     const static int8_t DEFAULT_STATUS_CODE;
 private:
-    void validateRowScehma(const std::vector<Column>& schema) const throw (InCompatibleSchemaException);
+    void validateRowScehma(const std::vector<Column>& schema) const;
     boost::shared_ptr<std::vector<voltdb::Column> > m_columns;
     int32_t m_rowCountPosition;
     int32_t m_rowCount;

--- a/include/TableIterator.h
+++ b/include/TableIterator.h
@@ -70,7 +70,7 @@ public:
      * more rows. OverflowUnderflowException and IndexOutOfBoundsException only result if there are bugs
      * and are not expected normally.
      */
-    voltdb::Row next() throw (NoMoreRowsException, OverflowUnderflowException, IndexOutOfBoundsException) {
+    voltdb::Row next() {
         if (m_rowCount <= m_currentRow) {
             throw NoMoreRowsException();
         }

--- a/include/TableIterator.h
+++ b/include/TableIterator.h
@@ -26,7 +26,6 @@
 
 #include "ByteBuffer.hpp"
 #include "Column.hpp"
-#include <boost/shared_ptr.hpp>
 #include "Row.hpp"
 #include "Exception.hpp"
 
@@ -45,12 +44,12 @@ public:
      */
 #ifdef SWIG
 %ignore TableIterator(voltdb::SharedByteBuffer rows,
-            boost::shared_ptr<std::vector<voltdb::Column> > columns,
+            std::shared_ptr<std::vector<voltdb::Column>> columns,
             int32_t rowCount);
 #endif
     TableIterator(
             voltdb::SharedByteBuffer rows,
-            boost::shared_ptr<std::vector<voltdb::Column> > columns,
+            std::shared_ptr<std::vector<voltdb::Column>> columns,
             int32_t rowCount) :
         m_buffer(rows), m_columns(columns), m_rowCount(rowCount), m_currentRow(0) {}
 
@@ -85,7 +84,7 @@ public:
 
 private:
     voltdb::SharedByteBuffer m_buffer;
-    boost::shared_ptr<std::vector<voltdb::Column> > m_columns;
+    std::shared_ptr<std::vector<voltdb::Column> > m_columns;
     int32_t m_rowCount;
     int32_t m_currentRow;
 };

--- a/include/property_tree/json_parser.hpp
+++ b/include/property_tree/json_parser.hpp
@@ -1,0 +1,140 @@
+// ----------------------------------------------------------------------------
+// Copyright (C) 2002-2006 Marcin Kalicinski
+// Copyright (C) 2015 Sebastian Redl
+//
+// Distributed under the Boost Software License, Version 1.0. 
+// (See accompanying file LICENSE_1_0.txt or copy at 
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// For more information, see www.boost.org
+// ----------------------------------------------------------------------------
+#ifndef BOOST_PROPERTY_TREE_JSON_PARSER_HPP_INCLUDED
+#define BOOST_PROPERTY_TREE_JSON_PARSER_HPP_INCLUDED
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser/error.hpp>
+#include <boost/property_tree/json_parser/detail/read.hpp>
+#include <boost/property_tree/json_parser/detail/write.hpp>
+
+#include <fstream>
+#include <string>
+#include <locale>
+
+namespace boost { namespace property_tree { namespace json_parser
+{
+
+    /**
+     * Read JSON from a the given stream and translate it to a property tree.
+     * @note Clears existing contents of property tree.  In case of error the
+     *       property tree unmodified.
+     * @note Items of JSON arrays are translated into ptree keys with empty
+     *       names. Members of objects are translated into named keys.
+     * @note JSON data can be a string, a numeric value, or one of literals
+     *       "null", "true" and "false". During parse, any of the above is
+     *       copied verbatim into ptree data string.
+     * @throw json_parser_error In case of error deserializing the property
+     *                          tree.
+     * @param stream Stream from which to read in the property tree.
+     * @param[out] pt The property tree to populate.
+     */
+    template<class Ptree>
+    void read_json(std::basic_istream<
+                       typename Ptree::key_type::value_type
+                   > &stream,
+                   Ptree &pt)
+    {
+        detail::read_json_internal(stream, pt, std::string());
+    }
+
+    /**
+     * Read JSON from a the given file and translate it to a property tree.
+     * @note Clears existing contents of property tree.  In case of error the
+     *       property tree unmodified.
+     * @note Items of JSON arrays are translated into ptree keys with empty
+     *       names. Members of objects are translated into named keys.
+     * @note JSON data can be a string, a numeric value, or one of literals
+     *       "null", "true" and "false". During parse, any of the above is
+     *       copied verbatim into ptree data string.
+     * @throw json_parser_error In case of error deserializing the property
+     *                          tree.
+     * @param filename Name of file from which to read in the property tree.
+     * @param[out] pt The property tree to populate.
+     * @param loc The locale to use when reading in the file contents.
+     */
+    template<class Ptree>
+    void read_json(const std::string &filename,
+                   Ptree &pt,
+                   const std::locale &loc = std::locale())
+    {
+        std::basic_ifstream<typename Ptree::key_type::value_type>
+            stream(filename.c_str());
+        if (!stream)
+            BOOST_PROPERTY_TREE_THROW(json_parser_error(
+                "cannot open file", filename, 0));
+        stream.imbue(loc);
+        detail::read_json_internal(stream, pt, filename);
+    }
+
+    /**
+     * Translates the property tree to JSON and writes it the given output
+     * stream.
+     * @note Any property tree key containing only unnamed subkeys will be
+     *       rendered as JSON arrays.
+     * @pre @e pt cannot contain keys that have both subkeys and non-empty data.
+     * @throw json_parser_error In case of error translating the property tree
+     *                          to JSON or writing to the output stream.
+     * @param stream The stream to which to write the JSON representation of the
+     *               property tree.
+     * @param pt The property tree to tranlsate to JSON and output.
+     * @param pretty Whether to pretty-print. Defaults to true for backward
+     *               compatibility.
+     */
+    template<class Ptree>
+    void write_json(std::basic_ostream<
+                        typename Ptree::key_type::value_type
+                    > &stream,
+                    const Ptree &pt,
+                    bool pretty = true)
+    {
+        write_json_internal(stream, pt, std::string(), pretty);
+    }
+
+    /**
+     * Translates the property tree to JSON and writes it the given file.
+     * @note Any property tree key containing only unnamed subkeys will be
+     *       rendered as JSON arrays.
+     * @pre @e pt cannot contain keys that have both subkeys and non-empty data.
+     * @throw json_parser_error In case of error translating the property tree
+     *                          to JSON or writing to the file.
+     * @param filename The name of the file to which to write the JSON
+     *                 representation of the property tree.
+     * @param pt The property tree to translate to JSON and output.
+     * @param loc The locale to use when writing out to the output file.
+     * @param pretty Whether to pretty-print. Defaults to true and last place
+     *               for backward compatibility.
+     */
+    template<class Ptree>
+    void write_json(const std::string &filename,
+                    const Ptree &pt,
+                    const std::locale &loc = std::locale(),
+                    bool pretty = true)
+    {
+        std::basic_ofstream<typename Ptree::key_type::value_type>
+            stream(filename.c_str());
+        if (!stream)
+            BOOST_PROPERTY_TREE_THROW(json_parser_error(
+                "cannot open file", filename, 0));
+        stream.imbue(loc);
+        write_json_internal(stream, pt, filename, pretty);
+    }
+
+} } }
+
+namespace boost { namespace property_tree
+{
+    using json_parser::read_json;
+    using json_parser::write_json;
+    using json_parser::json_parser_error;
+} }
+
+#endif

--- a/include/property_tree/ptree.hpp
+++ b/include/property_tree/ptree.hpp
@@ -1,0 +1,518 @@
+// ----------------------------------------------------------------------------
+// Copyright (C) 2002-2006 Marcin Kalicinski
+// Copyright (C) 2009 Sebastian Redl
+//
+// Distributed under the Boost Software License, Version 1.0. 
+// (See accompanying file LICENSE_1_0.txt or copy at 
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// For more information, see www.boost.org
+// ----------------------------------------------------------------------------
+
+#ifndef BOOST_PROPERTY_TREE_PTREE_HPP_INCLUDED
+#define BOOST_PROPERTY_TREE_PTREE_HPP_INCLUDED
+
+#include <boost/property_tree/ptree_fwd.hpp>
+#include <boost/property_tree/string_path.hpp>
+#include <boost/property_tree/stream_translator.hpp>
+#include <boost/property_tree/exceptions.hpp>
+#include <boost/property_tree/detail/ptree_utils.hpp>
+
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/indexed_by.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/throw_exception.hpp>
+#include <boost/optional.hpp>
+#include <utility>                  // for std::pair
+
+namespace boost { namespace property_tree
+{
+
+    /**
+     * Property tree main structure. A property tree is a hierarchical data
+     * structure which has one element of type @p Data in each node, as well
+     * as an ordered sequence of sub-nodes, which are additionally identified
+     * by a non-unique key of type @p Key.
+     *
+     * Key equivalency is defined by @p KeyCompare, a predicate defining a
+     * strict weak ordering.
+     *
+     * Property tree defines a Container-like interface to the (key-node) pairs
+     * of its direct sub-nodes. The iterators are bidirectional. The sequence
+     * of nodes is held in insertion order, not key order.
+     */
+    template<class Key, class Data, class KeyCompare>
+    class basic_ptree
+    {
+#if defined(BOOST_PROPERTY_TREE_DOXYGEN_INVOKED)
+    public:
+#endif
+        // Internal types
+        /**
+         * Simpler way to refer to this basic_ptree\<C,K,P,A\> type.
+         * Note that this is private, and made public only for doxygen.
+         */
+        typedef basic_ptree<Key, Data, KeyCompare> self_type;
+
+    public:
+        // Basic types
+        typedef Key                                  key_type;
+        typedef Data                                 data_type;
+        typedef KeyCompare                           key_compare;
+
+        // Container view types
+        typedef std::pair<const Key, self_type>      value_type;
+        typedef std::size_t                          size_type;
+
+        // The problem with the iterators is that I can't make them complete
+        // until the container is complete. Sucks. Especially for the reverses.
+        class iterator;
+        class const_iterator;
+        class reverse_iterator;
+        class const_reverse_iterator;
+
+        // Associative view types
+        class assoc_iterator;
+        class const_assoc_iterator;
+
+        // Property tree view types
+        typedef typename path_of<Key>::type          path_type;
+
+
+        // The big five
+
+        /** Creates a node with no children and default-constructed data. */
+        basic_ptree();
+        /** Creates a node with no children and a copy of the given data. */
+        explicit basic_ptree(const data_type &data);
+        basic_ptree(const self_type &rhs);
+        ~basic_ptree();
+        /** Basic guarantee only. */
+        self_type &operator =(const self_type &rhs);
+
+        /** Swap with other tree. Only constant-time and nothrow if the
+         * data type's swap is.
+         */
+        void swap(self_type &rhs);
+
+        // Container view functions
+
+        /** The number of direct children of this node. */
+        size_type size() const;
+        size_type max_size() const;
+        /** Whether there are any direct children. */
+        bool empty() const;
+
+        iterator begin();
+        const_iterator begin() const;
+        iterator end();
+        const_iterator end() const;
+        reverse_iterator rbegin();
+        const_reverse_iterator rbegin() const;
+        reverse_iterator rend();
+        const_reverse_iterator rend() const;
+
+        value_type &front();
+        const value_type &front() const;
+        value_type &back();
+        const value_type &back() const;
+
+        /** Insert a copy of the given tree with its key just before the given
+         * position in this node. This operation invalidates no iterators.
+         * @return An iterator to the newly created child.
+         */
+        iterator insert(iterator where, const value_type &value);
+
+        /** Range insert. Equivalent to:
+         * @code
+         * for(; first != last; ++first) insert(where, *first);
+         * @endcode
+         */
+        template<class It> void insert(iterator where, It first, It last);
+
+        /** Erase the child pointed at by the iterator. This operation
+         * invalidates the given iterator, as well as its equivalent
+         * assoc_iterator.
+         * @return A valid iterator pointing to the element after the erased.
+         */
+        iterator erase(iterator where);
+
+        /** Range erase. Equivalent to:
+         * @code
+         * while(first != last;) first = erase(first);
+         * @endcode
+         */
+        iterator erase(iterator first, iterator last);
+
+        /** Equivalent to insert(begin(), value). */
+        iterator push_front(const value_type &value);
+
+        /** Equivalent to insert(end(), value). */
+        iterator push_back(const value_type &value);
+
+        /** Equivalent to erase(begin()). */
+        void pop_front();
+
+        /** Equivalent to erase(boost::prior(end())). */
+        void pop_back();
+
+        /** Reverses the order of direct children in the property tree. */
+        void reverse();
+
+        /** Sorts the direct children of this node according to the predicate.
+         * The predicate is passed the whole pair of key and child.
+         */
+        template<class Compare> void sort(Compare comp);
+
+        /** Sorts the direct children of this node according to key order. */
+        void sort();
+
+        // Equality
+
+        /** Two property trees are the same if they have the same data, the keys
+         * and order of their children are the same, and the children compare
+         * equal, recursively.
+         */
+        bool operator ==(const self_type &rhs) const;
+        bool operator !=(const self_type &rhs) const;
+
+        // Associative view
+
+        /** Returns an iterator to the first child, in key order. */
+        assoc_iterator ordered_begin();
+        /** Returns an iterator to the first child, in key order. */
+        const_assoc_iterator ordered_begin() const;
+
+        /** Returns the not-found iterator. Equivalent to end() in a real
+         * associative container.
+         */
+        assoc_iterator not_found();
+        /** Returns the not-found iterator. Equivalent to end() in a real
+         * associative container.
+         */
+        const_assoc_iterator not_found() const;
+
+        /** Find a child with the given key, or not_found() if there is none.
+         * There is no guarantee about which child is returned if multiple have
+         * the same key.
+         */
+        assoc_iterator find(const key_type &key);
+
+        /** Find a child with the given key, or not_found() if there is none.
+         * There is no guarantee about which child is returned if multiple have
+         * the same key.
+         */
+        const_assoc_iterator find(const key_type &key) const;
+
+        /** Find the range of children that have the given key. */
+        std::pair<assoc_iterator, assoc_iterator>
+            equal_range(const key_type &key);
+
+        /** Find the range of children that have the given key. */
+        std::pair<const_assoc_iterator, const_assoc_iterator>
+            equal_range(const key_type &key) const;
+
+        /** Count the number of direct children with the given key. */
+        size_type count(const key_type &key) const;
+
+        /** Erase all direct children with the given key and return the count.
+         */
+        size_type erase(const key_type &key);
+
+        /** Get the iterator that points to the same element as the argument.
+         * @note A valid assoc_iterator range (a, b) does not imply that
+         *       (to_iterator(a), to_iterator(b)) is a valid range.
+         */
+        iterator to_iterator(assoc_iterator it);
+
+        /** Get the iterator that points to the same element as the argument.
+         * @note A valid const_assoc_iterator range (a, b) does not imply that
+         *       (to_iterator(a), to_iterator(b)) is a valid range.
+         */
+        const_iterator to_iterator(const_assoc_iterator it) const;
+
+        // Property tree view
+
+        /** Reference to the actual data in this node. */
+        data_type &data();
+
+        /** Reference to the actual data in this node. */
+        const data_type &data() const;
+
+        /** Clear this tree completely, of both data and children. */
+        void clear();
+
+        /** Get the child at the given path, or throw @c ptree_bad_path.
+         * @note Depending on the path, the result at each level may not be
+         *       completely deterministic, i.e. if the same key appears multiple
+         *       times, which child is chosen is not specified. This can lead
+         *       to the path not being resolved even though there is a
+         *       descendant with this path. Example:
+         * @code
+         *   a -> b -> c
+         *     -> b
+         * @endcode
+         *       The path "a.b.c" will succeed if the resolution of "b" chooses
+         *       the first such node, but fail if it chooses the second.
+         */
+        self_type &get_child(const path_type &path);
+
+        /** Get the child at the given path, or throw @c ptree_bad_path. */
+        const self_type &get_child(const path_type &path) const;
+
+        /** Get the child at the given path, or return @p default_value. */
+        self_type &get_child(const path_type &path, self_type &default_value);
+
+        /** Get the child at the given path, or return @p default_value. */
+        const self_type &get_child(const path_type &path,
+                                   const self_type &default_value) const;
+
+        /** Get the child at the given path, or return boost::null. */
+        optional<self_type &> get_child_optional(const path_type &path);
+
+        /** Get the child at the given path, or return boost::null. */
+        optional<const self_type &>
+          get_child_optional(const path_type &path) const;
+
+        /** Set the node at the given path to the given value. Create any
+         * missing parents. If the node at the path already exists, replace it.
+         * @return A reference to the inserted subtree.
+         * @note Because of the way paths work, it is not generally guaranteed
+         *       that a node newly created can be accessed using the same path.
+         * @note If the path could refer to multiple nodes, it is unspecified
+         *       which one gets replaced.
+         */
+        self_type &put_child(const path_type &path, const self_type &value);
+
+        /** Add the node at the given path. Create any missing parents. If there
+         * already is a node at the path, add another one with the same key.
+         * @param path Path to the child. The last fragment must not have an
+         *             index.
+         * @return A reference to the inserted subtree.
+         * @note Because of the way paths work, it is not generally guaranteed
+         *       that a node newly created can be accessed using the same path.
+         */
+        self_type &add_child(const path_type &path, const self_type &value);
+
+        /** Take the value of this node and attempt to translate it to a
+         * @c Type object using the supplied translator.
+         * @throw ptree_bad_data if the conversion fails.
+         */
+        template<class Type, class Translator>
+        typename boost::enable_if<detail::is_translator<Translator>, Type>::type
+        get_value(Translator tr) const;
+
+        /** Take the value of this node and attempt to translate it to a
+         * @c Type object using the default translator.
+         * @throw ptree_bad_data if the conversion fails.
+         */
+        template<class Type>
+        Type get_value() const;
+
+        /** Take the value of this node and attempt to translate it to a
+         * @c Type object using the supplied translator. Return @p default_value
+         * if this fails.
+         */
+        template<class Type, class Translator>
+        Type get_value(const Type &default_value, Translator tr) const;
+
+        /** Make get_value do the right thing for string literals. */
+        template <class Ch, class Translator>
+        typename boost::enable_if<
+            detail::is_character<Ch>,
+            std::basic_string<Ch>
+        >::type
+        get_value(const Ch *default_value, Translator tr) const;
+
+        /** Take the value of this node and attempt to translate it to a
+         * @c Type object using the default translator. Return @p default_value
+         * if this fails.
+         */
+        template<class Type>
+        typename boost::disable_if<detail::is_translator<Type>, Type>::type
+        get_value(const Type &default_value) const;
+
+        /** Make get_value do the right thing for string literals. */
+        template <class Ch>
+        typename boost::enable_if<
+            detail::is_character<Ch>,
+            std::basic_string<Ch>
+        >::type
+        get_value(const Ch *default_value) const;
+
+        /** Take the value of this node and attempt to translate it to a
+         * @c Type object using the supplied translator. Return boost::null if
+         * this fails.
+         */
+        template<class Type, class Translator>
+        optional<Type> get_value_optional(Translator tr) const;
+
+        /** Take the value of this node and attempt to translate it to a
+         * @c Type object using the default translator. Return boost::null if
+         * this fails.
+         */
+        template<class Type>
+        optional<Type> get_value_optional() const;
+
+        /** Replace the value at this node with the given value, translated
+         * to the tree's data type using the supplied translator.
+         * @throw ptree_bad_data if the conversion fails.
+        */
+        template<class Type, class Translator>
+        void put_value(const Type &value, Translator tr);
+
+        /** Replace the value at this node with the given value, translated
+         * to the tree's data type using the default translator.
+         * @throw ptree_bad_data if the conversion fails.
+        */
+        template<class Type>
+        void put_value(const Type &value);
+
+        /** Shorthand for get_child(path).get_value(tr). */
+        template<class Type, class Translator>
+        typename boost::enable_if<detail::is_translator<Translator>, Type>::type
+        get(const path_type &path, Translator tr) const;
+
+        /** Shorthand for get_child(path).get_value\<Type\>(). */
+        template<class Type>
+        Type get(const path_type &path) const;
+
+        /** Shorthand for get_child(path, empty_ptree())
+         *                    .get_value(default_value, tr).
+         * That is, return the translated value if possible, and the default
+         * value if the node doesn't exist or conversion fails.
+         */
+        template<class Type, class Translator>
+        Type get(const path_type &path,
+                 const Type &default_value,
+                 Translator tr) const;
+
+        /** Make get do the right thing for string literals. */
+        template <class Ch, class Translator>
+        typename boost::enable_if<
+            detail::is_character<Ch>,
+            std::basic_string<Ch>
+        >::type
+        get(const path_type &path, const Ch *default_value, Translator tr)const;
+
+        /** Shorthand for get_child(path, empty_ptree())
+         *                    .get_value(default_value).
+         * That is, return the translated value if possible, and the default
+         * value if the node doesn't exist or conversion fails.
+         */
+        template<class Type>
+        typename boost::disable_if<detail::is_translator<Type>, Type>::type
+        get(const path_type &path, const Type &default_value) const;
+
+        /** Make get do the right thing for string literals. */
+        template <class Ch>
+        typename boost::enable_if<
+            detail::is_character<Ch>,
+            std::basic_string<Ch>
+        >::type
+        get(const path_type &path, const Ch *default_value) const;
+
+        /** Shorthand for:
+         * @code
+         * if(optional\<self_type&\> node = get_child_optional(path))
+         *   return node->get_value_optional(tr);
+         * return boost::null;
+         * @endcode
+         * That is, return the value if it exists and can be converted, or nil.
+        */
+        template<class Type, class Translator>
+        optional<Type> get_optional(const path_type &path, Translator tr) const;
+
+        /** Shorthand for:
+         * @code
+         * if(optional\<const self_type&\> node = get_child_optional(path))
+         *   return node->get_value_optional();
+         * return boost::null;
+         * @endcode
+         * That is, return the value if it exists and can be converted, or nil.
+        */
+        template<class Type>
+        optional<Type> get_optional(const path_type &path) const;
+
+        /** Set the value of the node at the given path to the supplied value,
+         * translated to the tree's data type. If the node doesn't exist, it is
+         * created, including all its missing parents.
+         * @return The node that had its value changed.
+         * @throw ptree_bad_data if the conversion fails.
+        */
+        template<class Type, class Translator>
+        self_type &put(const path_type &path, const Type &value, Translator tr);
+
+        /** Set the value of the node at the given path to the supplied value,
+         * translated to the tree's data type. If the node doesn't exist, it is
+         * created, including all its missing parents.
+         * @return The node that had its value changed.
+         * @throw ptree_bad_data if the conversion fails.
+        */
+        template<class Type>
+        self_type &put(const path_type &path, const Type &value);
+
+        /** If the node identified by the path does not exist, create it,
+         * including all its missing parents.
+         * If the node already exists, add a sibling with the same key.
+         * Set the newly created node's value to the given paremeter,
+         * translated with the supplied translator.
+         * @param path Path to the child. The last fragment must not have an
+         *             index.
+         * @param value The value to add.
+         * @param tr The translator to use.
+         * @return The node that was added.
+         * @throw ptree_bad_data if the conversion fails.
+        */
+        template<class Type, class Translator>
+        self_type &add(const path_type &path,
+                       const Type &value,
+                       Translator tr);
+
+        /** If the node identified by the path does not exist, create it,
+         * including all its missing parents.
+         * If the node already exists, add a sibling with the same key.
+         * Set the newly created node's value to the given paremeter,
+         * translated with the supplied translator.
+         * @param path Path to the child. The last fragment must not have an
+         *             index.
+         * @param value The value to add.
+         * @return The node that was added.
+         * @throw ptree_bad_data if the conversion fails.
+        */
+        template<class Type>
+        self_type &add(const path_type &path, const Type &value);
+
+    private:
+        // Hold the data of this node
+        data_type m_data;
+        // Hold the children - this is a void* because we can't complete the
+        // container type within the class.
+        void* m_children;
+
+        // Getter tree-walk. Not const-safe! Gets the node the path refers to,
+        // or null. Destroys p's value.
+        self_type* walk_path(path_type& p) const;
+
+        // Modifer tree-walk. Gets the parent of the node referred to by the
+        // path, creating nodes as necessary. p is the path to the remaining
+        // child.
+        self_type& force_path(path_type& p);
+
+        // This struct contains typedefs for the concrete types.
+        struct subs;
+        friend struct subs;
+        friend class iterator;
+        friend class const_iterator;
+        friend class reverse_iterator;
+        friend class const_reverse_iterator;
+    };
+
+}}
+
+#include <boost/property_tree/detail/ptree_implementation.hpp>
+
+#endif

--- a/makefile
+++ b/makefile
@@ -91,9 +91,7 @@ $(LIB_NAME).so: $(OBJS)
 $(KIT_NAME).tar.gz: $(LIB_NAME).a $(LIB_NAME).so
 	@echo 'Building distribution kit'
 	rm -rf $(KIT_NAME)
-	mkdir -p $(KIT_NAME)/include/ttmath
-	mkdir -p $(KIT_NAME)/include/openssl
-	mkdir -p $(KIT_NAME)/$(THIRD_PARTY_DIR)
+	mkdir -p $(KIT_NAME)/include/ttmath $(KIT_NAME)/include/openssl $(KIT_NAME)/include/property_tree $(KIT_NAME)/$(THIRD_PARTY_DIR)
 
 	cp -R include/ByteBuffer.hpp include/Client.h include/ClientConfig.h \
 		  include/Column.hpp include/ConnectionPool.h include/Decimal.hpp \

--- a/makefile
+++ b/makefile
@@ -4,38 +4,37 @@
 #
 BUILD=RELEASE
 ifeq (${BUILD},RELEASE)
-OPTIMIZATION=-O3
+	  OPTIMIZATION=-O3
+else
+	  OPTIMIZATION=-g3
 endif
-
-CC=g++
-BOOST_INCLUDES=/usr/local/include
-BOOST_LIBS=/usr/local/lib
 
 LIB_NAME=libvoltdbcpp
-KIT_NAME=voltdb-client-cpp-x86_64-7.1
+KIT_NAME=voltdb-client-cpp-x86_64-8.4
 
-CFLAGS=-I$(BOOST_INCLUDES) -Iinclude -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -g3 ${OPTIMIZATION} -fPIC
+CXXFLAGS=-Iinclude -std=c++11 ${OPTIMIZATION} -fPIC
 PLATFORM = $(shell uname)
 
-ifeq ($(PLATFORM),Darwin)
-	THIRD_PARTY_DIR := third_party_libs/osx
-	THIRD_PARTY_LIBS := $(THIRD_PARTY_DIR)/libevent.a \
-					$(THIRD_PARTY_DIR)/libevent_openssl.a \
-					$(THIRD_PARTY_DIR)/libevent_pthreads.a \
-					$(THIRD_PARTY_DIR)/libssl.a \
-					$(THIRD_PARTY_DIR)/libcrypto.a
-	SYSTEM_LIBS := -L$(BOOST_LIBS) -lc -lpthread -lboost_system-mt -lboost_thread-mt
-endif
 
-ifeq ($(PLATFORM),Linux)
-	THIRD_PARTY_DIR := third_party_libs/linux
-	THIRD_PARTY_LIBS := $(THIRD_PARTY_DIR)/libevent.a \
-					$(THIRD_PARTY_DIR)/libevent_openssl.a \
-					$(THIRD_PARTY_DIR)/libevent_pthreads.a \
-					$(THIRD_PARTY_DIR)/libssl.a \
-					$(THIRD_PARTY_DIR)/libcrypto.a \
-					-ldl
-	SYSTEM_LIBS := -L $(BOOST_LIBS) -lc -lpthread -lrt -lboost_system -lboost_thread
+ifeq ($(PLATFORM),Darwin)
+	  THIRD_PARTY_DIR := third_party_libs/osx
+	  THIRD_PARTY_LIBS := $(THIRD_PARTY_DIR)/libevent.a \
+		    $(THIRD_PARTY_DIR)/libevent_openssl.a \
+		    $(THIRD_PARTY_DIR)/libevent_pthreads.a \
+		    $(THIRD_PARTY_DIR)/libssl.a \
+		    $(THIRD_PARTY_DIR)/libcrypto.a
+	  SYSTEM_LIBS := -lc -lpthread
+else ifeq ($(PLATFORM),Linux)
+	  THIRD_PARTY_DIR := third_party_libs/linux
+	  THIRD_PARTY_LIBS := $(THIRD_PARTY_DIR)/libevent.a \
+		    $(THIRD_PARTY_DIR)/libevent_openssl.a \
+		    $(THIRD_PARTY_DIR)/libevent_pthreads.a \
+		    $(THIRD_PARTY_DIR)/libssl.a \
+		    $(THIRD_PARTY_DIR)/libcrypto.a \
+		    -ldl
+	  SYSTEM_LIBS := -lc -lpthread -lrt
+else
+	  $(error "Unsupported platform $(PLATFORM)")
 endif
 
 .PHONEY: all clean test kit
@@ -64,41 +63,27 @@ TEST_OBJS := test_obj/ByteBufferTest.o \
 CPTEST_OBJS := test_obj/ConnectionPoolTest.o \
 			 test_obj/Tests.o
 
-RM := rm -rf
+RM := $(RM) -r
 
 # All Target
 all: $(KIT_NAME).tar.gz
 
 obj/%.o: src/%.cpp | obj
-	@echo 'Building file: $<'
-	@echo 'Invoking: GCC C++ Compiler'
-	$(CC) $(CFLAGS) -c -o $@ $< -MMD -MP
-	@echo 'Finished building: $<'
-	@echo ' '
+	$(CXX) $(CXXFLAGS) -c -o $@ $< -MMD -MP
 
 obj/%.o: src/%.c | obj
-	@echo 'Building file: $<'
-	@echo 'Invoking: GCC C Compiler'
-	$(CC) $(CFLAGS) -c -o $@ $< -MMD -MP
-	@echo 'Finished building: $<'
-	@echo ' '
+	$(CXX) $(CXXFLAGS) -c -o $@ $< -MMD -MP
 
 test_obj/%.o: test_src/%.cpp | test_obj
-	@echo 'Building file: $<'
-	@echo 'Invoking: GCC C Compiler'
-	$(CC) $(CFLAGS) -c -o $@ $< -MMD -MP
-	@echo 'Finished building: $<'
-	@echo ' '
+	$(CXX) $(CXXFLAGS) -c -o $@ $< -MMD -MP
 
 $(LIB_NAME).a: $(OBJS)
 	@echo 'Building libvoltdbcpp.a static library'
 	$(AR) $(ARFLAGS) $@ $?
-	@echo ' '
 
 $(LIB_NAME).so: $(OBJS)
 	@echo 'Building libvoltdbcpp.so shared library'
-	$(CC) -shared -o $@ $? $(THIRD_PARTY_LIBS) $(SYSTEM_LIBS)
-	@echo
+	$(CXX) $(CXXFLAGS) -shared -o $@ $? $(THIRD_PARTY_LIBS) $(SYSTEM_LIBS)
 
 -include $(OBJS:.o=.d)
 -include $(TEST_OBJS:.o=.d)
@@ -116,10 +101,11 @@ $(KIT_NAME).tar.gz: $(LIB_NAME).a $(LIB_NAME).so
 		  include/ParameterSet.hpp include/Procedure.hpp include/ProcedureCallback.hpp \
 		  include/Row.hpp include/RowBuilder.h include/StatusListener.h include/Table.h \
 		  include/TableIterator.h include/WireType.h include/TheHashinator.h \
-                  include/ClientLogger.h include/Distributer.h include/ElasticHashinator.h \
-                  include/MurmurHash3.h include/Geography.hpp include/GeographyPoint.hpp $(KIT_NAME)/include/
+		  include/ClientLogger.h include/Distributer.h include/ElasticHashinator.h \
+		  include/MurmurHash3.h include/Geography.hpp include/GeographyPoint.hpp $(KIT_NAME)/include/
 	cp -R include/ttmath/*.h $(KIT_NAME)/include/ttmath/
 	cp include/openssl/*.h $(KIT_NAME)/include/openssl/
+	cp include/property_tree/*.hpp $(KIT_NAME)/include/property_tree
 
 	cp -R examples $(KIT_NAME)/
 	cp README.md $(KIT_NAME)/
@@ -130,28 +116,22 @@ $(KIT_NAME).tar.gz: $(LIB_NAME).a $(LIB_NAME).so
 
 	tar -czf $(KIT_NAME).tar.gz $(KIT_NAME)
 
-	@echo
-
 testbin: $(LIB_NAME).a $(TEST_OBJS)
 	@echo 'Compiling CPPUnit tests'
-	$(CC) $(CFLAGS) $(TEST_OBJS) $(LIB_NAME).a $(THIRD_PARTY_LIBS) $(SYSTEM_LIBS) -lcppunit -o testbin
-	@echo ' '
+	$(CXX) $(CXXFLAGS) $(TEST_OBJS) $(LIB_NAME).a $(THIRD_PARTY_LIBS) $(SYSTEM_LIBS) -lcppunit -o testbin
 
 test: testbin
 	@echo 'Running CPPUnit tests'
 	./testbin
-	@echo ' '
 
 # Connection pool testing is put separately since for now it requires a local running Volt server
 cptestbin: $(LIB_NAME).a $(CPTEST_OBJS)
 	@echo 'Compiling Connection Pool CPPUnit tests'
-	$(CC) $(CFLAGS) $(CPTEST_OBJS) $(LIB_NAME).a $(THIRD_PARTY_LIBS) $(SYSTEM_LIBS) -lcppunit -o cptestbin
-	@echo ' '
+	$(CXX) $(CXXFLAGS) $(CPTEST_OBJS) $(LIB_NAME).a $(THIRD_PARTY_LIBS) $(SYSTEM_LIBS) -lcppunit -o cptestbin
 
 cptest: cptestbin
 	@echo 'Running Connection Pool CPPUnit tests'
 	./cptestbin
-	@echo ' '
 
 obj:
 	mkdir -p obj
@@ -161,18 +141,7 @@ test_obj:
 
 # Other Targets
 clean:
-	-$(RM) $(OBJS)
-	-$(RM) $(OBJS:.o=.d);
-	-$(RM) $(TEST_OBJS)
-	-$(RM) $(TEST_OBJS:.o=.d);
-	-$(RM) $(CPTEST_OBJS)
-	-$(RM) testbin*
-	-$(RM) cptestbin*
-	-$(RM) $(LIB_NAME).a
-	-$(RM) $(LIB_NAME).so
-	-$(RM) $(KIT_NAME)
-	-$(RM) $(KIT_NAME).tgz
-	-$(RM) obj test_obj
-	-@echo ' '
-	-cd examples; make clean
+	-$(RM) $(OBJS) $(OBJS:.o=.d) $(TEST_OBJS) $(TEST_OBJS:.o=.d) $(CPTEST_OBJS) testbin* cptestbin* \
+		  $(LIB_NAME).a $(LIB_NAME).so $(KIT_NAME) $(KIT_NAME).tgz obj test_obj
+	$(MAKE) -C examples clean
 # DO NOT DELETE

--- a/makefile
+++ b/makefile
@@ -13,6 +13,7 @@ LIB_NAME=libvoltdbcpp
 KIT_NAME=voltdb-client-cpp-x86_64-8.4
 
 CXXFLAGS=-Iinclude -std=c++11 ${OPTIMIZATION} -fPIC
+CFLAGS=-Iinclude ${OPTIMIZATION} -fPIC
 PLATFORM = $(shell uname)
 
 
@@ -39,29 +40,29 @@ endif
 
 .PHONEY: all clean test kit
 
-OBJS := obj/Client.o \
-		obj/ClientConfig.o \
-		obj/ClientImpl.o \
-		obj/ConnectionPool.o \
-		obj/RowBuilder.o \
-		obj/Table.o \
-		obj/WireType.o \
-		obj/Distributer.o \
-		obj/MurmurHash3.o \
-		obj/GeographyPoint.o \
-		obj/Geography.o
+OBJS := obj/CAPI.o obj/Client.o \
+	  obj/ClientConfig.o \
+	  obj/ClientImpl.o \
+	  obj/ConnectionPool.o \
+	  obj/RowBuilder.o \
+	  obj/Table.o \
+	  obj/WireType.o \
+	  obj/Distributer.o \
+	  obj/MurmurHash3.o \
+	  obj/GeographyPoint.o \
+	  obj/Geography.o
 
 TEST_OBJS := test_obj/ByteBufferTest.o \
-			 test_obj/MockVoltDB.o \
-			 test_obj/ClientTest.o \
-			 test_obj/SerializationTest.o \
-			 test_obj/GeographyPointTest.o \
-			 test_obj/GeographyTest.o \
-			 test_obj/TableTest.o \
-			 test_obj/Tests.o
+	  test_obj/MockVoltDB.o \
+	  test_obj/ClientTest.o \
+	  test_obj/SerializationTest.o \
+	  test_obj/GeographyPointTest.o \
+	  test_obj/GeographyTest.o \
+	  test_obj/TableTest.o \
+	  test_obj/Tests.o
 
 CPTEST_OBJS := test_obj/ConnectionPoolTest.o \
-			 test_obj/Tests.o
+	  test_obj/Tests.o
 
 RM := $(RM) -r
 
@@ -72,7 +73,7 @@ obj/%.o: src/%.cpp | obj
 	$(CXX) $(CXXFLAGS) -c -o $@ $< -MMD -MP
 
 obj/%.o: src/%.c | obj
-	$(CXX) $(CXXFLAGS) -c -o $@ $< -MMD -MP
+	$(CC) $(CFLAGS) -c -o $@ $< -MMD -MP
 
 test_obj/%.o: test_src/%.cpp | test_obj
 	$(CXX) $(CXXFLAGS) -c -o $@ $< -MMD -MP
@@ -93,7 +94,7 @@ $(KIT_NAME).tar.gz: $(LIB_NAME).a $(LIB_NAME).so
 	rm -rf $(KIT_NAME)
 	mkdir -p $(KIT_NAME)/include/ttmath $(KIT_NAME)/include/openssl $(KIT_NAME)/include/property_tree $(KIT_NAME)/$(THIRD_PARTY_DIR)
 
-	cp -R include/ByteBuffer.hpp include/Client.h include/ClientConfig.h \
+	cp -R include/CAPI.h include/ByteBuffer.hpp include/Client.h include/ClientConfig.h \
 		  include/Column.hpp include/ConnectionPool.h include/Decimal.hpp \
 		  include/Exception.hpp include/InvocationResponse.hpp include/Parameter.hpp \
 		  include/ParameterSet.hpp include/Procedure.hpp include/ProcedureCallback.hpp \

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -1,0 +1,120 @@
+
+#include "CAPI.h"
+#include "ClientImpl.h"
+#include "TableIterator.h"
+#include "Row.hpp"
+
+c_client c_create_client(const char* usrname, const char* pwd,
+      const char* hostname, unsigned short port, bool keepConnecting,
+      /*voltdb::ClientAuthHashScheme schema,*/ bool enableAbandon, bool enableTimeout,
+      int timeoutInSec, bool useSSL) {
+   voltdb::ClientConfig* client_config = new voltdb::ClientConfig(
+         usrname, pwd, voltdb::HASH_SHA1/*schema*/, enableAbandon,
+         enableTimeout, timeoutInSec, useSSL);
+   voltdb::Client* client = new voltdb::Client(new voltdb::ClientImpl(*client_config));
+   client->createConnection(hostname, port, keepConnecting);
+   return {
+      .client_config = client_config, .client = client
+   };
+}
+
+void c_close(c_client* client) {
+   if (client != nullptr) {
+      client->client->close();
+      delete client->client;
+      delete client->client_config;
+   }
+}
+
+c_procedure c_create_procedure(const char* name,
+      int nparams, voltdb::Parameter* params) {
+   c_procedure proc;
+   proc.numParams = nparams;
+   for (int index = 0; index < nparams; ++index) {
+      proc.parameters.push_back(params[index]);
+   }
+   proc.procedure = new voltdb::Procedure(name, proc.parameters);
+   return proc;
+}
+
+c_procedure c_create_call() {
+   c_procedure proc;
+   proc.numParams = 1;
+   proc.parameters = std::vector<voltdb::Parameter>(1, voltdb::WIRE_TYPE_STRING);
+   proc.procedure = new voltdb::Procedure("@AdHoc", proc.parameters);
+   return proc;
+}
+
+void c_drop_procedure(c_procedure* proc) {
+   if (proc != nullptr) {
+      delete proc->procedure;
+   }
+}
+
+c_invocation_response c_exec_proc(c_client* client, c_procedure* proc, const char** params) {
+   if (client == nullptr || proc == nullptr) {
+      throw std::runtime_error("Client or Proc unset.");
+   } else if (proc->parameters.cend() !=
+         std::find_if(proc->parameters.cbegin(), proc->parameters.cend(), [](voltdb::Parameter const& p) {
+            return p.m_type != voltdb::WIRE_TYPE_STRING; })) {
+      throw std::runtime_error("Only string typed parameter is supported");
+   } else {
+      voltdb::ParameterSet* p = proc->procedure->params();
+      for (int index = 0; index < proc->numParams; ++index) {
+         p->addString(params[index]);
+      }
+      return {.response = client->client->invoke(*proc->procedure)};
+   }
+}
+
+int c_status_code(c_invocation_response* response) {
+   return response->response.statusCode();
+}
+
+c_stringified_tables c_exec_result(c_invocation_response* response) {
+   const std::vector<voltdb::Table> tables = response->response.results();
+   c_stringified_tables result;
+   result.num_tables = tables.size();
+   if (tables.empty()) {
+      result.tables = nullptr;
+   } else {
+      result.tables = new c_stringified_table[result.num_tables];
+      for(int tbl_index = 0; tbl_index < result.num_tables; ++tbl_index) {
+         const voltdb::Table& table = tables[tbl_index];
+         voltdb::TableIterator iter = table.iterator();
+         c_stringified_table* ctable = &result.tables[tbl_index];
+         ctable->num_cols = table.columnCount();
+         ctable->num_rows = table.rowCount();
+         ctable->tuples = new char**[ctable->num_rows];
+         for(int row_index = 0; row_index < ctable->num_rows; ++row_index) {
+            ctable->tuples[row_index] = new char*[ctable->num_cols];
+            voltdb::Row row = iter.next();
+            for(int col_index = 0; col_index < ctable->num_cols; ++col_index) {
+               const std::string& val = row.get(col_index);
+               const size_t len = val.size();
+               ctable->tuples[row_index][col_index] = new char[len + 1];
+               memcpy(ctable->tuples[row_index][col_index], val.c_str(), len);
+               ctable->tuples[row_index][col_index][len] = '\0';
+            }
+         }
+      }
+   }
+   return result;
+}
+
+void c_destroy_result(c_stringified_tables* result) {
+   if (result != nullptr) {
+      for(int tbl_index = 0; tbl_index < result->num_tables; ++tbl_index) {
+         c_stringified_table* tbl = &result->tables[tbl_index];
+         for(int row_index = 0; row_index < tbl->num_rows; ++row_index) {
+            for(int col_index = 0; col_index < tbl->num_cols; ++col_index) {
+               delete[] tbl->tuples[row_index][col_index];
+            }
+            delete[] tbl->tuples[row_index];
+         }
+         delete[] tbl->tuples;
+         delete tbl;
+      }
+   }
+}
+

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -1,10 +1,26 @@
+#include <algorithm>
 
 #include "CAPI.h"
 #include "ClientImpl.h"
 #include "TableIterator.h"
 #include "Row.hpp"
 
-c_client c_create_client(const char* usrname, const char* pwd,
+struct c_client {
+   voltdb::ClientConfig* client_config;
+   voltdb::Client* client;
+};
+
+struct c_procedure {
+   voltdb::Procedure* procedure;
+   int numParams;
+   std::vector<voltdb::Parameter>* parameters;
+};
+
+struct c_invocation_response {
+   voltdb::InvocationResponse* response;
+};
+
+c_client* c_create_client(const char* usrname, const char* pwd,
       const char* hostname, unsigned short port, bool keepConnecting,
       /*voltdb::ClientAuthHashScheme schema,*/ bool enableAbandon, bool enableTimeout,
       int timeoutInSec, bool useSSL) {
@@ -13,9 +29,10 @@ c_client c_create_client(const char* usrname, const char* pwd,
          enableTimeout, timeoutInSec, useSSL);
    voltdb::Client* client = new voltdb::Client(new voltdb::ClientImpl(*client_config));
    client->createConnection(hostname, port, keepConnecting);
-   return {
-      .client_config = client_config, .client = client
-   };
+   c_client* rclient = new c_client;
+   rclient->client_config = client_config;
+   rclient->client = client;
+   return rclient;
 }
 
 void c_close(c_client* client) {
@@ -23,66 +40,94 @@ void c_close(c_client* client) {
       client->client->close();
       delete client->client;
       delete client->client_config;
+      delete client;
    }
 }
 
-c_procedure c_create_procedure(const char* name,
+c_procedure* c_create_procedure(const char* name,
       int nparams, voltdb::Parameter* params) {
-   c_procedure proc;
-   proc.numParams = nparams;
+   c_procedure* proc = new c_procedure;
+   proc->numParams = nparams;
+   proc->parameters = new std::vector<voltdb::Parameter>();
    for (int index = 0; index < nparams; ++index) {
-      proc.parameters.push_back(params[index]);
+      proc->parameters->push_back(params[index]);
    }
-   proc.procedure = new voltdb::Procedure(name, proc.parameters);
+   proc->procedure = new voltdb::Procedure(name, *proc->parameters);
    return proc;
 }
 
-c_procedure c_create_call() {
-   c_procedure proc;
-   proc.numParams = 1;
-   proc.parameters = std::vector<voltdb::Parameter>(1, voltdb::WIRE_TYPE_STRING);
-   proc.procedure = new voltdb::Procedure("@AdHoc", proc.parameters);
+c_procedure* c_create_call() {
+   c_procedure* proc = new c_procedure;
+   proc->numParams = 1;
+   proc->parameters = new std::vector<voltdb::Parameter>();
+   proc->parameters->push_back(voltdb::WIRE_TYPE_STRING);
+   proc->procedure = new voltdb::Procedure("@AdHoc", *proc->parameters);
    return proc;
 }
 
 void c_drop_procedure(c_procedure* proc) {
    if (proc != nullptr) {
+      delete proc->parameters;
       delete proc->procedure;
+      delete proc;
    }
 }
 
-c_invocation_response c_exec_proc(c_client* client, c_procedure* proc, const char** params) {
+c_invocation_response* c_exec_proc(c_client* client, c_procedure* proc, const char** params) {
    if (client == nullptr || proc == nullptr) {
-      throw std::runtime_error("Client or Proc unset.");
-   } else if (proc->parameters.cend() !=
-         std::find_if(proc->parameters.cbegin(), proc->parameters.cend(), [](voltdb::Parameter const& p) {
+      if(client == nullptr) {
+         fprintf(stderr, "Client is null\n");
+      }
+      if (proc == nullptr) {
+         fprintf(stderr, "Procedure is null\n");
+      }
+      return nullptr;
+   } else if (proc->parameters->cend() !=
+         std::find_if(proc->parameters->cbegin(), proc->parameters->cend(), [](voltdb::Parameter const& p) {
             return p.m_type != voltdb::WIRE_TYPE_STRING; })) {
-      throw std::runtime_error("Only string typed parameter is supported");
+      // Support full range of types requires some boiler-plate
+      // for serializing/deserializing from char*, hence not
+      // supported.
+      fprintf(stderr, "Only string typed parameter is supported\n");
+      return nullptr;
    } else {
       voltdb::ParameterSet* p = proc->procedure->params();
       for (int index = 0; index < proc->numParams; ++index) {
          p->addString(params[index]);
       }
-      return {.response = client->client->invoke(*proc->procedure)};
+      c_invocation_response* response = new c_invocation_response;
+      response->response =
+         new voltdb::InvocationResponse(std::move(client->client->invoke(*proc->procedure)));
+      return response;
    }
 }
 
-int c_status_code(c_invocation_response* response) {
-   return response->response.statusCode();
+c_invocation_response* c_exec_adhoc(struct c_client* client, struct c_procedure* proc, const char* param) {
+   const char* params[] = {param, nullptr};
+   return c_exec_proc(client, proc, params);
 }
 
-c_stringified_tables c_exec_result(c_invocation_response* response) {
-   const std::vector<voltdb::Table> tables = response->response.results();
-   c_stringified_tables result;
-   result.num_tables = tables.size();
+void c_destroy_response(c_invocation_response* response) {
+   delete response->response;
+   delete response;
+}
+
+int c_status_code(c_invocation_response* response) {
+   return response->response->statusCode();
+}
+
+c_stringified_tables* c_exec_result(c_invocation_response* response) {
+   const std::vector<voltdb::Table> tables = response->response->results();
+   c_stringified_tables* result = new c_stringified_tables;
+   result->num_tables = tables.size();
    if (tables.empty()) {
-      result.tables = nullptr;
+      result->tables = nullptr;
    } else {
-      result.tables = new c_stringified_table[result.num_tables];
-      for(int tbl_index = 0; tbl_index < result.num_tables; ++tbl_index) {
+      result->tables = new c_stringified_table[result->num_tables];
+      for(int tbl_index = 0; tbl_index < result->num_tables; ++tbl_index) {
          const voltdb::Table& table = tables[tbl_index];
          voltdb::TableIterator iter = table.iterator();
-         c_stringified_table* ctable = &result.tables[tbl_index];
+         c_stringified_table* ctable = &result->tables[tbl_index];
          ctable->num_cols = table.columnCount();
          ctable->num_rows = table.rowCount();
          ctable->tuples = new char**[ctable->num_rows];

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -26,7 +26,7 @@
 
 namespace voltdb {
 
-Client Client::create(ClientConfig config) throw (voltdb::Exception, voltdb::LibEventException) {
+Client Client::create(ClientConfig config) {
     Client client(new ClientImpl(config));
     return client;
 }
@@ -38,9 +38,7 @@ Client::~Client() {
 
 void Client::createConnection(const std::string &hostname,
                               const unsigned short port,
-                              const bool keepConnecting) throw (voltdb::Exception,
-                                                                voltdb::ConnectException,
-                                                                voltdb::LibEventException) {
+                              const bool keepConnecting) {
     m_impl->createConnection(hostname, port, keepConnecting);
 }
 
@@ -51,50 +49,33 @@ void Client::close() {
 /*
  * Synchronously invoke a stored procedure and return a the response.
  */
-InvocationResponse Client::invoke(Procedure &proc) throw (voltdb::Exception,
-                                                          voltdb::NoConnectionsException,
-                                                          voltdb::UninitializedParamsException,
-                                                          voltdb::LibEventException) {
+InvocationResponse Client::invoke(Procedure &proc) {
     return m_impl->invoke(proc);
 }
 
 void Client::invoke(Procedure &proc,
-                    boost::shared_ptr<ProcedureCallback> callback) throw (voltdb::Exception,
-                                                                          voltdb::NoConnectionsException,
-                                                                          voltdb::UninitializedParamsException,
-                                                                          voltdb::LibEventException) {
+                    boost::shared_ptr<ProcedureCallback> callback) {
     m_impl->invoke(proc, callback);
 }
 
 void Client::invoke(Procedure &proc,
-                    ProcedureCallback *callback) throw (voltdb::Exception,
-                                                        voltdb::NoConnectionsException,
-                                                        voltdb::UninitializedParamsException,
-                                                        voltdb::LibEventException) {
+                    ProcedureCallback *callback) {
     m_impl->invoke(proc, callback);
 }
 
-void Client::runOnce() throw (voltdb::Exception,
-                              voltdb::NoConnectionsException,
-                              voltdb::LibEventException) {
+void Client::runOnce() {
     m_impl->runOnce();
 }
 
-void Client::run() throw (voltdb::Exception,
-                          voltdb::NoConnectionsException,
-                          voltdb::LibEventException) {
+void Client::run() {
     m_impl->run();
 }
 
-void Client::runForMaxTime(uint64_t uSec) throw (voltdb::Exception,
-                                                 voltdb::NoConnectionsException,
-                                                 voltdb::LibEventException) {
+void Client::runForMaxTime(uint64_t uSec) {
     m_impl->runForMaxTime(uSec);
 }
 
-bool Client::drain() throw (voltdb::Exception,
-                            voltdb::NoConnectionsException,
-                            voltdb::LibEventException) {
+bool Client::drain() {
     return m_impl->drain();
 }
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -54,7 +54,7 @@ InvocationResponse Client::invoke(Procedure &proc) {
 }
 
 void Client::invoke(Procedure &proc,
-                    boost::shared_ptr<ProcedureCallback> callback) {
+                    std::shared_ptr<ProcedureCallback> callback) {
     m_impl->invoke(proc, callback);
 }
 

--- a/src/ClientConfig.cpp
+++ b/src/ClientConfig.cpp
@@ -31,7 +31,7 @@ public:
     DummyStatusListener(StatusListener *listener) : m_listener(listener) {}
     bool uncaughtException(
             std::exception exception,
-            boost::shared_ptr<voltdb::ProcedureCallback> callback,
+            std::shared_ptr<voltdb::ProcedureCallback> callback,
             InvocationResponse response) {
         if (m_listener != NULL) {
             return m_listener->uncaughtException(exception, callback, response);
@@ -93,7 +93,7 @@ public:
     ClientConfig::ClientConfig(
             std::string username,
             std::string password,
-            boost::shared_ptr<StatusListener> listener, ClientAuthHashScheme scheme, bool enableAbandon,
+            std::shared_ptr<StatusListener> listener, ClientAuthHashScheme scheme, bool enableAbandon,
             bool enableQueryTimeout, int timeoutInSeconds, bool useSSL) :
                 m_username(username), m_password(password), m_listener(listener),
                 m_maxOutstandingRequests(3000), m_hashScheme(scheme), m_enableAbandon(enableAbandon),

--- a/src/ClientImpl.cpp
+++ b/src/ClientImpl.cpp
@@ -20,15 +20,18 @@
  * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  * OTHER DEALINGS IN THE SOFTWARE.
  */
-#include "ClientImpl.h"
+#include <algorithm>
 #include <cassert>
-#include "AuthenticationResponse.hpp"
-#include "AuthenticationRequest.hpp"
 #include <event2/buffer.h>
 #include <event2/thread.h>
 #include <event2/event.h>
 #include <sstream>
 #include <openssl/err.h>
+#include <unistd.h>
+
+#include "ClientImpl.h"
+#include "AuthenticationResponse.hpp"
+#include "AuthenticationRequest.hpp"
 
 #define HIGH_WATERMARK 1024 * 1024 * 55
 #define RECONNECT_INTERVAL 10

--- a/src/ConnectionPool.cpp
+++ b/src/ConnectionPool.cpp
@@ -50,7 +50,7 @@ public:
 
     bool uncaughtException(
             std::exception exception,
-            boost::shared_ptr<voltdb::ProcedureCallback> callback,
+            std::shared_ptr<voltdb::ProcedureCallback> callback,
             InvocationResponse response) {
         if (m_listener != NULL) {
             return m_listener->uncaughtException(exception, callback, response);
@@ -179,10 +179,10 @@ ConnectionPool::acquireClient(
         }
     }
 
-    std::vector<boost::shared_ptr<ClientStuff> > *clientStuffs = &m_clients[identifier];
+    std::vector<std::shared_ptr<ClientStuff>> *clientStuffs = &m_clients[identifier];
 
     while (clientStuffs->size() > 0) {
-        boost::shared_ptr<ClientStuff> clientStuff = clientStuffs->back();
+        std::shared_ptr<ClientStuff> clientStuff = clientStuffs->back();
         clientStuffs->pop_back();
 
         // run the event loop once to verify the connection is still available
@@ -203,7 +203,7 @@ ConnectionPool::acquireClient(
     DelegatingStatusListener *delegatingListener = new DelegatingStatusListener();
     Client client = voltdb::Client::create(ClientConfig( username, password, delegatingListener, sha));
     client.createConnection(hostname, port);
-    boost::shared_ptr<ClientStuff> stuff(new ClientStuff(client, identifier, delegatingListener));
+    std::shared_ptr<ClientStuff> stuff(new ClientStuff(client, identifier, delegatingListener));
     stuff->m_listener->m_listener = listener;
     clients->push_back(stuff);
     return client;

--- a/src/ConnectionPool.cpp
+++ b/src/ConnectionPool.cpp
@@ -25,7 +25,6 @@
 #include <cassert>
 #include <exception>
 #include <iostream>
-#include <boost/scoped_ptr.hpp>
 #include <cstdio>
 #include "InvocationResponse.hpp"
 #include "ClientConfig.h"
@@ -125,7 +124,7 @@ void cleanupOnScriptEnd(void *ptr) {
         LockGuard guard(gPool->m_lock);
         ClientSet *clients = reinterpret_cast<ClientSet*>(ptr);
         if (clients != NULL) {
-            boost::scoped_ptr<ClientSet> guard(clients);
+           std::unique_ptr<ClientSet> guard(clients);
             for(ClientSet::iterator i = clients->begin(); i != clients->end(); i++) {
                 (*i)->m_listener->m_listener = NULL;
                 gPool->m_clients[(*i)->m_identifier].push_back(*i);

--- a/src/ConnectionPool.cpp
+++ b/src/ConnectionPool.cpp
@@ -160,8 +160,7 @@ ConnectionPool::acquireClient(
         std::string password,
         StatusListener *listener,
         unsigned short port,
-        ClientAuthHashScheme sha)
-throw (voltdb::Exception, voltdb::ConnectException, voltdb::LibEventException) {
+        ClientAuthHashScheme sha) {
     LockGuard guard(m_lock);
     ClientSet *clients = reinterpret_cast<ClientSet*>(pthread_getspecific(m_borrowedClients));
     if (clients == NULL) {
@@ -216,12 +215,11 @@ ConnectionPool::acquireClient(
         std::string username,
         std::string password,
         unsigned short port,
-        ClientAuthHashScheme sha)
-throw (voltdb::Exception, voltdb::ConnectException, voltdb::LibEventException) {
+        ClientAuthHashScheme sha) {
     return acquireClient(hostname, username, password, NULL, port, sha);
 }
 
-void ConnectionPool::returnClient(Client client) throw (voltdb::Exception) {
+void ConnectionPool::returnClient(Client client) {
     LockGuard guard(m_lock);
     ClientSet *clients = reinterpret_cast<ClientSet*>(pthread_getspecific(m_borrowedClients));
     if (clients == NULL) {
@@ -240,7 +238,7 @@ void ConnectionPool::returnClient(Client client) throw (voltdb::Exception) {
     throw MisplacedClientException();
 }
 
-void ConnectionPool::closeClientConnection(Client client) throw (voltdb::Exception) {
+void ConnectionPool::closeClientConnection(Client client) {
     LockGuard guard(m_lock);
     ClientSet *clients = reinterpret_cast<ClientSet*>(pthread_getspecific(m_borrowedClients));
     if (clients == NULL) {

--- a/src/Distributer.cpp
+++ b/src/Distributer.cpp
@@ -30,8 +30,8 @@
 #include "Table.h"
 #include "TableIterator.h"
 #include "Row.hpp"
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "property_tree/ptree.hpp"
+#include "property_tree/json_parser.hpp"
 #include <stdlib.h>
 namespace voltdb {
 

--- a/src/Distributer.cpp
+++ b/src/Distributer.cpp
@@ -127,8 +127,7 @@ int Distributer::getHashedPartitionForParameter(ByteBuffer &paramBuffer, int par
     return parseParameter(paramBuffer, index);
 }
 
-ProcedureInfo* Distributer::getProcedure(const std::string& procName) throw (UnknownProcedureException)
-{
+ProcedureInfo* Distributer::getProcedure(const std::string& procName) {
     std::map<std::string, ProcedureInfo>::iterator it = m_procedureInfo.find(procName);
     if (it == m_procedureInfo.end())
         return NULL;

--- a/src/Distributer.cpp
+++ b/src/Distributer.cpp
@@ -21,7 +21,6 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <boost/shared_ptr.hpp>
 #include "Distributer.h"
 #include "InvocationResponse.hpp"
 #include "ProcedureCallback.hpp"

--- a/src/Geography.cpp
+++ b/src/Geography.cpp
@@ -21,6 +21,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <algorithm>
 #include <iostream>
 #include <sstream>
 #include <stdint.h>

--- a/src/GeographyPoint.cpp
+++ b/src/GeographyPoint.cpp
@@ -30,6 +30,8 @@
 #include "ByteBuffer.hpp"
 
 namespace voltdb {
+const double GeographyPoint::NULL_COORDINATE = 360.0;
+
 GeographyPoint::GeographyPoint()
     : m_longitude(360.0),
       m_latitude(360.0) {

--- a/src/RowBuilder.cpp
+++ b/src/RowBuilder.cpp
@@ -25,7 +25,7 @@
 #include "Table.h"
 
 namespace voltdb {
-    RowBuilder::RowBuilder(const std::vector<Column> &schema) throw (RowCreationException) :
+    RowBuilder::RowBuilder(const std::vector<Column> &schema) :
     m_columns(schema), m_buffer(8192), m_currentColumnIndex(0) {
         if (m_columns.empty()) {
             throw RowCreationException("The schema for row must contain at least one column");

--- a/src/Table.cpp
+++ b/src/Table.cpp
@@ -35,8 +35,8 @@ namespace voltdb {
         buffer.position(5);
         size_t columnCount = static_cast<size_t>(buffer.getInt16());
         assert(columnCount > 0);
-        boost::shared_ptr<std::vector< voltdb::Column> > columns(
-                                new std::vector< voltdb::Column>(columnCount));
+        std::shared_ptr<std::vector<voltdb::Column>> columns(
+              new std::vector<voltdb::Column>(columnCount));
         m_columns = columns;
 
         std::vector<int8_t> types(columnCount);
@@ -232,7 +232,7 @@ namespace voltdb {
         int32_t size;
         istream.read((char*)&size, sizeof(size));
         if (size != 0) {
-            boost::shared_array<char> buffer(new char[size]);
+            std::shared_ptr<char[]> buffer(new char[size]);
             istream.read(buffer.get(), size);
             return voltdb::SharedByteBuffer(buffer, size);
         } else {

--- a/src/Table.cpp
+++ b/src/Table.cpp
@@ -54,7 +54,7 @@ namespace voltdb {
         m_buffer.position(m_buffer.limit());
     }
 
-    Table::Table(const std::vector<Column> &columns) throw (TableException) {
+    Table::Table(const std::vector<Column> &columns) {
         if (columns.empty()) {
             throw TableException("Failed to create table. Provided schema can't be empty, "
                     "it must contain at least one column");
@@ -145,13 +145,13 @@ namespace voltdb {
         }
     }
 
-    void Table::validateRowScehma(const std::vector<Column>& schema) const throw (InCompatibleSchemaException) {
+    void Table::validateRowScehma(const std::vector<Column>& schema) const {
         if (schema.empty() || schema != *m_columns) {
             throw (InCompatibleSchemaException());
         }
     }
 
-    void Table::addRow(RowBuilder& row) throw (TableException, UninitializedColumnException, InCompatibleSchemaException) {
+    void Table::addRow(RowBuilder& row) {
         const std::vector<Column> schema = row.columns();
         validateRowScehma(schema);
         m_buffer.limit(m_buffer.capacity());
@@ -185,7 +185,7 @@ namespace voltdb {
      * in the passed in byte buffer to serialize the data. Needed space
      * to serialize can be obtained by Table::getSerializedSize()
      */
-    int32_t Table::serializeTo(ByteBuffer& buffer) throw (TableException){
+    int32_t Table::serializeTo(ByteBuffer& buffer) {
         buffer.limit(buffer.capacity());
         if (buffer.remaining() < getSerializedSize()) {
             throw TableException("Cannot serialize table as the specified buffer is not large enough. "

--- a/test_src/ByteBufferTest.cpp
+++ b/test_src/ByteBufferTest.cpp
@@ -25,7 +25,6 @@
 #include <cppunit/TestFixture.h>
 #include "Exception.hpp"
 #include "ByteBuffer.hpp"
-#include <boost/scoped_ptr.hpp>
 
 namespace voltdb {
 

--- a/test_src/ClientTest.cpp
+++ b/test_src/ClientTest.cpp
@@ -576,7 +576,7 @@ public:
 
 private:
     Client *m_client;
-    boost::scoped_ptr<MockVoltDB> m_voltdb;
+    std::unique_ptr<MockVoltDB> m_voltdb;
     std::shared_ptr<DelegatingListener> *m_dlistener;
 };
 CPPUNIT_TEST_SUITE_REGISTRATION( ClientTest );

--- a/test_src/ClientTest.cpp
+++ b/test_src/ClientTest.cpp
@@ -44,7 +44,7 @@ public:
    }
    virtual bool uncaughtException(
            std::exception exception,
-           boost::shared_ptr<voltdb::ProcedureCallback> callback,
+           std::shared_ptr<voltdb::ProcedureCallback> callback,
            InvocationResponse response) {
        if (m_listener != NULL) {
            return m_listener->uncaughtException(exception, callback, response);
@@ -94,7 +94,7 @@ CPPUNIT_TEST_SUITE_END();
 
 public:
     void setUp() {
-        m_dlistener = new boost::shared_ptr<DelegatingListener>(new DelegatingListener());
+        m_dlistener = new std::shared_ptr<DelegatingListener>(new DelegatingListener());
         ClientConfig config = ClientConfig("hello", "world", *m_dlistener);
         m_voltdb.reset(new MockVoltDB(Client::create(config)));
         m_client = m_voltdb->client();
@@ -188,7 +188,7 @@ public:
         m_voltdb->filenameForNextResponse("invocation_response_success.msg");
 
         SyncCallback *cb = new SyncCallback();
-        boost::shared_ptr<ProcedureCallback> callback(cb);
+        std::shared_ptr<ProcedureCallback> callback(cb);
         (m_client)->invoke(proc, callback);
         while (!cb->m_hasResponse) {
             (m_client)->runOnce();
@@ -228,7 +228,7 @@ public:
         Procedure proc("foo", signature);
         proc.params();
         SyncCallback *cb = new SyncCallback();
-        boost::shared_ptr<ProcedureCallback> callback(cb);
+        std::shared_ptr<ProcedureCallback> callback(cb);
         (m_client)->invoke(proc, callback);
     }
 
@@ -244,7 +244,7 @@ public:
         std::vector<Parameter> signature;
         Procedure proc("foo", signature);
         proc.params();
-        (m_client)->invoke(proc, boost::shared_ptr<ProcedureCallback>());
+        (m_client)->invoke(proc, std::shared_ptr<ProcedureCallback>());
     }
 
     void testLostConnection() {
@@ -255,7 +255,7 @@ public:
            Listener() : lostReported(false), activeReported(false) {}
             virtual bool uncaughtException(
                     std::exception exception,
-                    boost::shared_ptr<voltdb::ProcedureCallback> callback,
+                    std::shared_ptr<voltdb::ProcedureCallback> callback,
                     InvocationResponse response) {
                 CPPUNIT_ASSERT(false);
                 return false;
@@ -282,7 +282,7 @@ public:
         proc.params();
 
         SyncCallback *cb = new SyncCallback();
-        boost::shared_ptr<ProcedureCallback> callback(cb);
+        std::shared_ptr<ProcedureCallback> callback(cb);
         (m_client)->invoke(proc, callback);
         m_voltdb->hangupOnRequestCount(1);
 
@@ -330,7 +330,7 @@ public:
         public:
             virtual bool uncaughtException(
                     std::exception exception,
-                    boost::shared_ptr<voltdb::ProcedureCallback> callback,
+                    std::shared_ptr<voltdb::ProcedureCallback> callback,
                     InvocationResponse response) {
                 CPPUNIT_ASSERT(false);
                 return false;
@@ -356,7 +356,7 @@ public:
         proc.params();
 
         SyncCallback *cb = new SyncCallback();
-        boost::shared_ptr<ProcedureCallback> callback(cb);
+        std::shared_ptr<ProcedureCallback> callback(cb);
         (m_client)->invoke(proc, callback);
         m_voltdb->hangupOnRequestCount(1);
 
@@ -385,7 +385,7 @@ public:
         m_voltdb->filenameForNextResponse("invocation_response_success.msg");
 
         BreakingSyncCallback *cb = new BreakingSyncCallback();
-        boost::shared_ptr<ProcedureCallback> callback(cb);
+        std::shared_ptr<ProcedureCallback> callback(cb);
         (m_client)->invoke(proc, callback);
 
         (m_client)->run();
@@ -406,7 +406,7 @@ public:
            Listener() : lostReported(false), activeReported(false) {}
             virtual bool uncaughtException(
                     std::exception exception,
-                    boost::shared_ptr<voltdb::ProcedureCallback> callback,
+                    std::shared_ptr<voltdb::ProcedureCallback> callback,
                     InvocationResponse response) {
                 lostReported = true;
                 return true;
@@ -439,7 +439,7 @@ public:
         m_voltdb->filenameForNextResponse("invocation_response_success.msg");
 
         ThrowingCallback *cb = new ThrowingCallback();
-        boost::shared_ptr<ProcedureCallback> callback(cb);
+        std::shared_ptr<ProcedureCallback> callback(cb);
         (m_client)->invoke(proc, callback);
 
         (m_client)->run();
@@ -452,7 +452,7 @@ public:
            Listener() : reported(false) {}
             virtual bool uncaughtException(
                     std::exception exception,
-                    boost::shared_ptr<voltdb::ProcedureCallback> callback,
+                    std::shared_ptr<voltdb::ProcedureCallback> callback,
                     InvocationResponse response) {
                 CPPUNIT_ASSERT(false);
                 return true;
@@ -476,7 +476,7 @@ public:
         std::vector<Parameter> signature;
         Procedure proc("Insert", signature);
         SyncCallback *cb = new SyncCallback();
-        boost::shared_ptr<ProcedureCallback> callback(cb);
+        std::shared_ptr<ProcedureCallback> callback(cb);
         m_voltdb->dontRead();
         while (!listener.reported) {
             (m_client)->invoke(proc, callback);
@@ -504,7 +504,7 @@ public:
         Procedure proc("Insert", signature);
 
         CountingCallback *cb = new CountingCallback(5);
-        boost::shared_ptr<ProcedureCallback> callback(cb);
+        std::shared_ptr<ProcedureCallback> callback(cb);
         for (int ii = 0; ii < 5; ii++) {
             (m_client)->invoke( proc, callback);
         }
@@ -537,7 +537,7 @@ public:
         Procedure proc("Insert", signature);
 
         CountingSuccessAndConnectionLost *cb = new CountingSuccessAndConnectionLost();
-        boost::shared_ptr<ProcedureCallback> callback(cb);
+        std::shared_ptr<ProcedureCallback> callback(cb);
         for (int ii = 0; ii < 5; ii++) {
             (m_client)->invoke( proc, callback);
         }
@@ -557,7 +557,7 @@ public:
         Procedure proc("Insert", signature);
 
         CountingSuccessAndConnectionLost *cb = new CountingSuccessAndConnectionLost();
-        boost::shared_ptr<ProcedureCallback> callback(cb);
+        std::shared_ptr<ProcedureCallback> callback(cb);
 
         // Queue up two async SP invocations
         for (int ii = 0; ii < 2; ii++) {
@@ -577,7 +577,7 @@ public:
 private:
     Client *m_client;
     boost::scoped_ptr<MockVoltDB> m_voltdb;
-    boost::shared_ptr<DelegatingListener> *m_dlistener;
+    std::shared_ptr<DelegatingListener> *m_dlistener;
 };
 CPPUNIT_TEST_SUITE_REGISTRATION( ClientTest );
 }

--- a/test_src/ClientTest.cpp
+++ b/test_src/ClientTest.cpp
@@ -169,7 +169,7 @@ public:
         InvocationResponse m_response;
         bool m_hasResponse;
         SyncCallback() : m_hasResponse(false) {}
-        virtual bool callback(InvocationResponse response) throw (voltdb::Exception) {
+        virtual bool callback(InvocationResponse response) {
             m_response = response;
             m_hasResponse = true;
             return false;
@@ -367,7 +367,7 @@ public:
     class BreakingSyncCallback : public ProcedureCallback {
     public:
         InvocationResponse m_response;
-        virtual bool callback(InvocationResponse response) throw (voltdb::Exception) {
+        virtual bool callback(InvocationResponse response) {
             m_response = response;
             return true;
         }
@@ -393,7 +393,7 @@ public:
 
     class ThrowingCallback : public ProcedureCallback {
     public:
-        virtual bool callback(InvocationResponse response) throw (voltdb::Exception) {
+        virtual bool callback(InvocationResponse response) {
             throw voltdb::Exception();
         }
     };
@@ -488,7 +488,7 @@ public:
     public:
         CountingCallback(int32_t count) : m_count(count) {}
 
-        bool callback(voltdb::InvocationResponse response) throw (voltdb::Exception) {
+        bool callback(voltdb::InvocationResponse response) {
             m_count--;
 
             CPPUNIT_ASSERT(response.success());
@@ -517,7 +517,7 @@ public:
     public:
         CountingSuccessAndConnectionLost() : m_success(0), m_connectionLost(0) {}
 
-        bool callback(voltdb::InvocationResponse response) throw (voltdb::Exception) {
+        bool callback(voltdb::InvocationResponse response) {
             if (response.success()) {
                 m_success++;
             } else {

--- a/test_src/ConnectionPoolTest.cpp
+++ b/test_src/ConnectionPoolTest.cpp
@@ -82,7 +82,7 @@ public:
     }
 
 private:
-    boost::scoped_ptr<ConnectionPool> m_connectionPool;
+    std::unique_ptr<ConnectionPool> m_connectionPool;
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION( ConnectionPoolTest );

--- a/test_src/MockVoltDB.cpp
+++ b/test_src/MockVoltDB.cpp
@@ -30,8 +30,6 @@
 #include "ByteBuffer.hpp"
 #include <cstdio>
 #include <event2/buffer.h>
-#include <boost/scoped_ptr.hpp>
-#include <boost/scoped_array.hpp>
 
 namespace voltdb {
 
@@ -226,7 +224,7 @@ void MockVoltDB::readCallback(struct bufferevent *bev) {
         return;
     }
 
-    boost::shared_ptr<CxnContext> ctx = m_contexts[bev];
+    std::shared_ptr<CxnContext> ctx = m_contexts[bev];
     if (!ctx->m_authenticated) {
         if (m_hangupOnRequestCounter > 0) {
             m_hangupOnRequestCounter--;
@@ -249,7 +247,7 @@ void MockVoltDB::readCallback(struct bufferevent *bev) {
         evbuffer_remove(evbuf, lengthBytes, 4);
         ByteBuffer lengthBuffer(lengthBytes, 4);
         int32_t length = lengthBuffer.getInt32();
-        boost::scoped_array<char> message(new char[length]);
+        std::unique_ptr<char[]> message(new char[length]);
         evbuffer_remove(evbuf, message.get(), length );
         return;
     }
@@ -275,7 +273,7 @@ void MockVoltDB::readCallback(struct bufferevent *bev) {
         ByteBuffer lengthBuffer(lengthBytes, 4);
         int32_t length = lengthBuffer.getInt32();
         // message
-        boost::scoped_array<char> message(new char[length]);
+        std::unique_ptr<char[]> message(new char[length]);
         evbuffer_remove(evbuf, message.get(), length );
         ByteBuffer messageBuffer(message.get(), length);
         // ??
@@ -343,7 +341,7 @@ void MockVoltDB::acceptCallback(
     bufferevent_setwatermark( bev, EV_READ, 0, 256);
     bufferevent_enable(bev, EV_READ);
     m_connections.insert(bev);
-    m_contexts[bev] = boost::shared_ptr<CxnContext>(new CxnContext(""));
+    m_contexts[bev] = std::shared_ptr<CxnContext>(new CxnContext(""));
 }
 
 }

--- a/test_src/MockVoltDB.cpp
+++ b/test_src/MockVoltDB.cpp
@@ -165,8 +165,7 @@ void MockVoltDB::interrupt() {
     event_base_once(m_base, -1, EV_TIMEOUT, interrupt_callback, this, NULL);
 }
 
-void MockVoltDB::run() 
-throw (voltdb::Exception, voltdb::NoConnectionsException, voltdb::LibEventException) {
+void MockVoltDB::run() {
     if (event_base_dispatch(m_base) == -1) {
         throw voltdb::LibEventException();
     }
@@ -315,7 +314,7 @@ void MockVoltDB::readCallback(struct bufferevent *bev) {
                     m_timeoutCount--;
                 }
             }
-            
+
             response.putInt64( 5, clientData);
             evbuf = bufferevent_get_output(bev);
             if (evbuffer_add(evbuf, response.bytes(), static_cast<size_t>(response.remaining()))) {

--- a/test_src/MockVoltDB.h
+++ b/test_src/MockVoltDB.h
@@ -26,7 +26,6 @@
 #include <event2/event.h>
 #include <event2/bufferevent.h>
 #include <event2/listener.h>
-#include <boost/shared_ptr.hpp>
 #include <vector>
 #include <map>
 #include <set>
@@ -89,7 +88,7 @@ private:
     struct event_base *m_base;
     struct evconnlistener *m_listener;
     std::set<struct bufferevent*> m_connections;
-    std::map<struct bufferevent*, boost::shared_ptr<CxnContext> > m_contexts;
+    std::map<struct bufferevent*, std::shared_ptr<CxnContext> > m_contexts;
     std::string m_filenameForNextResponse;
     int32_t m_hangupOnRequestCounter;
     bool m_dontRead;

--- a/test_src/MockVoltDB.h
+++ b/test_src/MockVoltDB.h
@@ -55,7 +55,7 @@ public:
 
     void interrupt();
 
-    void run() throw (voltdb::Exception, voltdb::NoConnectionsException, voltdb::LibEventException);
+    void run();
     void filenameForNextResponse(std::string filename) {
         m_filenameForNextResponse = filename;
     }

--- a/test_src/SerializationTest.cpp
+++ b/test_src/SerializationTest.cpp
@@ -503,10 +503,10 @@ void testInvocationGeoInsert() {
     // compare originalRequest and generatedRequest.
     compareRequestMessages(originalRequest,  "original_insert_geo.msg",
                            generatedRequest, "generated_insert_geo.msg");
-    
+
     // Investigate the response.  This is less interesting.
     originalResponse.position(4);
-    boost::shared_array<char> copy(new char[originalResponse.remaining()]);
+    std::shared_ptr<char[]> copy(new char[originalResponse.remaining()]);
     originalResponse.get(copy.get(), originalResponse.remaining());
     InvocationResponse response(copy, originalResponse.capacity() - 4);
     CPPUNIT_ASSERT(response.success());
@@ -545,7 +545,7 @@ void testInvocationGeoInsertNulls() {
 
     // Investigate the original response.  Again, this is less interesting.
     originalResponse.position(4);
-    boost::shared_array<char> copy(new char[originalResponse.remaining()]);
+    std::shared_ptr<char[]> copy(new char[originalResponse.remaining()]);
     originalResponse.get(copy.get(), originalResponse.remaining());
     InvocationResponse response(copy, originalResponse.capacity() - 4);
     CPPUNIT_ASSERT(response.success());
@@ -598,7 +598,7 @@ void testInvocationAllParams() {
 void testInvocationResponseSuccess() {
     SharedByteBuffer original = fileAsByteBuffer("invocation_response_success.msg");
     original.position(4);
-    boost::shared_array<char> copy(new char[original.remaining()]);
+    std::shared_ptr<char[]> copy(new char[original.remaining()]);
     original.get(copy.get(), original.remaining());
     InvocationResponse response(copy, original.capacity() - 4);
     CPPUNIT_ASSERT(response.success());
@@ -613,7 +613,7 @@ void testInvocationResponseSuccess() {
 void testInvocationResponseFailCV() {
     SharedByteBuffer original = fileAsByteBuffer("invocation_response_fail_cv.msg");
     original.position(4);
-    boost::shared_array<char> copy(new char[original.remaining()]);
+    std::shared_ptr<char[]> copy(new char[original.remaining()]);
     original.get(copy.get(), original.remaining());
     InvocationResponse response(copy, original.capacity() - 4);
     CPPUNIT_ASSERT(response.failure());
@@ -629,7 +629,7 @@ void testInvocationResponseFailCV() {
 void testInvocationResponseSelect() {
     SharedByteBuffer original = fileAsByteBuffer("invocation_response_select.msg");
     original.position(4);
-    boost::shared_array<char> copy(new char[original.remaining()]);
+    std::shared_ptr<char[]> copy(new char[original.remaining()]);
     original.get(copy.get(), original.remaining());
     InvocationResponse response(copy, original.capacity() - 4);
     CPPUNIT_ASSERT(response.success());
@@ -665,7 +665,7 @@ void testInvocationResponseSelect() {
 void testInvocationGeoSelectBoth() {
     SharedByteBuffer original = fileAsByteBuffer("invocation_response_select_geo_both.msg");
     original.position(4);
-    boost::shared_array<char> copy(new char[original.remaining()]);
+    std::shared_ptr<char[]> copy(new char[original.remaining()]);
     original.get(copy.get(), original.remaining());
     InvocationResponse response(copy, original.capacity() - 4);
     CPPUNIT_ASSERT(response.success());
@@ -725,7 +725,7 @@ void testInvocationGeoSelectBoth() {
 void testInvocationGeoSelectBothMid() {
     SharedByteBuffer original = fileAsByteBuffer("invocation_response_select_geo_both_mid.msg");
     original.position(4);
-    boost::shared_array<char> copy(new char[original.remaining()]);
+    std::shared_ptr<char[]> copy(new char[original.remaining()]);
     original.get(copy.get(), original.remaining());
     InvocationResponse response(copy, original.capacity() - 4);
     CPPUNIT_ASSERT(response.success());
@@ -784,7 +784,7 @@ void testInvocationGeoSelectBothMid() {
 void testInvocationGeoSelectPolyNull() {
     SharedByteBuffer original = fileAsByteBuffer("invocation_response_select_geo_polynull.msg");
     original.position(4);
-    boost::shared_array<char> copy(new char[original.remaining()]);
+    std::shared_ptr<char[]> copy(new char[original.remaining()]);
     original.get(copy.get(), original.remaining());
     InvocationResponse response(copy, original.capacity() - 4);
     CPPUNIT_ASSERT(response.success());
@@ -840,7 +840,7 @@ void testInvocationGeoSelectPolyNull() {
 void testInvocationGeoSelectPointNull() {
     SharedByteBuffer original = fileAsByteBuffer("invocation_response_select_geo_ptnull.msg");
     original.position(4);
-    boost::shared_array<char> copy(new char[original.remaining()]);
+    std::shared_ptr<char[]> copy(new char[original.remaining()]);
     original.get(copy.get(), original.remaining());
     InvocationResponse response(copy, original.capacity() - 4);
     CPPUNIT_ASSERT(response.success());
@@ -899,7 +899,7 @@ void testInvocationGeoSelectPointNull() {
 void testInvocationGeoSelectBothNull() {
     SharedByteBuffer original = fileAsByteBuffer("invocation_response_select_geo_bothnull.msg");
     original.position(4);
-    boost::shared_array<char> copy(new char[original.remaining()]);
+    std::shared_ptr<char[]> copy(new char[original.remaining()]);
     original.get(copy.get(), original.remaining());
     InvocationResponse response(copy, original.capacity() - 4);
     CPPUNIT_ASSERT(response.success());

--- a/test_src/SerializationTest.cpp
+++ b/test_src/SerializationTest.cpp
@@ -24,7 +24,6 @@
 #include <cppunit/TestCase.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestFixture.h>
-#include <boost/scoped_ptr.hpp>
 #include <iostream>
 #include <exception>
 #include <cstdio>

--- a/test_src/TableTest.cpp
+++ b/test_src/TableTest.cpp
@@ -27,7 +27,6 @@
 #include "TableIterator.h"
 #include "RowBuilder.h"
 #include "Decimal.hpp"
-#include <boost/scoped_ptr.hpp>
 
 namespace voltdb {
 
@@ -270,7 +269,7 @@ private:
             }
             case WIRE_TYPE_VARBINARY: {
                 uint8_t* data = (uint8_t*) malloc(sizeof(m_binData));
-                boost::scoped_ptr<uint8_t> value(data);
+                std::unique_ptr<uint8_t> value(data);
                 int outLen = 0;
                 bool status = row.getVarbinary(i, sizeof(m_binData), data, &outLen);
                 CPPUNIT_ASSERT(status);
@@ -344,7 +343,7 @@ private:
 
             case WIRE_TYPE_VARBINARY: {
                 uint8_t* data = (uint8_t*) malloc(sizeof(m_binData));
-                boost::scoped_ptr<uint8_t> value(data);
+                std::unique_ptr<uint8_t> value(data);
                 int outLen = 0;
                 bool status = row.getVarbinary(i, sizeof(m_binData), data, &outLen);
                 CPPUNIT_ASSERT(status);
@@ -459,7 +458,7 @@ private:
             // serialization
             int32_t tableSerializeSize = table.getSerializedSize();
             char *data = new char[tableSerializeSize];
-            boost::scoped_ptr<char> scopedData(data);
+            std::unique_ptr<char> scopedData(data);
             ByteBuffer tableBB(scopedData.get(), tableSerializeSize);
             int32_t serializedSize = table.serializeTo(tableBB);
             if (tableSerializeSize != serializedSize) {


### PR DESCRIPTION
Innovation project follow-up: a simple C-wrapper for the C++ client.

Together included are:
1. Current C++ client does not build on my box with latest compiler (Ubuntu-18.4; GCC-7.3.0), because some warnings are now treated as errors; and a ton of deprecated, pre-C++00 usage are treated as warnings. I suppressed those error/warnings.
2. Cleaned/rewrote build script.
3. Removed dependency of boost library. We mostly use smart pointers from boost, which are now available in C++11 standard. Use the standard library to replace most boost usage. For a single usage of Boost::Property_Tree, I copied relevant headers to `include/` directory. Therefore, building the client **no longer** needs Boost library.